### PR TITLE
augment.lm for missing observations

### DIFF
--- a/R/lm-tidiers.R
+++ b/R/lm-tidiers.R
@@ -134,19 +134,26 @@ tidy.lm <- function(x, conf.int=FALSE, conf.level=.95,
 #' @export
 augment.lm <- function(x, data = x$model, ...) {
     # move rownames if necessary
-    data <- fix_data_frame(data, newcol=".rownames")
-    
+	# here we need rownames to match the observations in the case of missing data (!)
+    data$.rownames <- rownames(data) 
+	
     infl <- influence(x, do.coef = FALSE)
-    data$.hat <- infl$hat
-    data$.sigma <- infl$sigma
-    data$.cooksd <- cooks.distance(x, infl)
-
-    data$.fitted <- predict(x)
-    data$.resid <- resid(x)
-    data$.stdresid <- rstandard(x, infl)
+	infl <- as.data.frame(infl)
+	infl$.rownames <- rownames(infl)
+	
+	
+	infl <- select(infl, .hat=hat,.sigma=sigma,.rownames)
+	
+	infl$.resid <- resid(x)
+	infl$.fitted <- predict(x)
+    infl$.cooksd <- cooks.distance(x)
+    infl$.stdresid <- rstandard(x)
     
+	data <- merge(data,infl,by=".rownames",all.x=TRUE)
+	
     data
 }
+
 
 
 #' @rdname lm-tidiers


### PR DESCRIPTION
Old version of augment.lm will stop with error when there are missing observations in the original data.frame.
This is due to different number of rows in original data.frame and x$model. This pull request corrects this error.

Try doing the following:

cars_na <- cars
cars_na$speed[7] <- NA

model <- lm(data=cars_na,dist~speed)
augment(model,cars_na)

A great idea of a package :)
