### PR TITLE
 Rename LCL and UCL using positions

### DIFF
--- a/R/survival_tidiers.R
+++ b/R/survival_tidiers.R
@@ -366,7 +366,7 @@ glance.coxph <- function(x, ...) {
 #'   \item{time}{timepoint}
 #'   \item{n.risk}{number of subjects at risk at time t0}
 #'   \item{n.event}{number of events at time t}
-#'   \item{n.censor}{n.censor}{number of censored events}
+#'   \item{n.censor}{number of censored events}
 #'   \item{estimate}{estimate of survival}
 #'   \item{std.error}{standard error of estimate}
 #'   \item{conf.high}{upper end of confidence interval}

--- a/man/survfit_tidiers.Rd
+++ b/man/survfit_tidiers.Rd
@@ -22,7 +22,7 @@ structure depends on the method chosen.
   \item{time}{timepoint}
   \item{n.risk}{number of subjects at risk at time t0}
   \item{n.event}{number of events at time t}
-  \item{n.censor}{n.censor}{number of censored events}
+  \item{n.censor}{number of censored events}
   \item{estimate}{estimate of survival}
   \item{std.error}{standard error of estimate}
   \item{conf.high}{upper end of confidence interval}


### PR DESCRIPTION
The names `0.95LCL` and `0.95UCL` depend on `conf.int`, which can be changed by the user.
