### PR TITLE
Make tidy() and glance() handle survfit() objects with missing CIs

### DIFF
--- a/man/survfit_tidiers.Rd
+++ b/man/survfit_tidiers.Rd
@@ -26,8 +26,8 @@ structure depends on the method chosen.
   \item{n.censor}{number of censored events}
   \item{estimate}{estimate of survival or cumulative incidence rate when multistate}
   \item{std.error}{standard error of estimate}
-  \item{conf.high}{upper end of confidence interval}
-  \item{conf.low}{lower end of confidence interval}
+  \item{conf.low}{lower end of confidence interval (if present in \code{x})}
+  \item{conf.high}{upper end of confidence interval (if present in \code{x})}
   \item{state}{state if multistate survfit object inputted}
   \item{strata}{strata if stratified survfit object inputted}
 
@@ -40,8 +40,8 @@ displayed by \code{\link{print.survfit}}
   \item{rmean}{Restricted mean (see \link[survival]{print.survfit})}
   \item{rmean.std.error}{Restricted mean standard error}
   \item{median}{median survival}
-  \item{conf.low}{lower end of confidence interval on median}
-  \item{conf.high}{upper end of confidence interval on median}
+  \item{conf.low}{lower end of confidence interval on median (if present in \code{x})}
+  \item{conf.high}{upper end of confidence interval on median (if present in \code{x})}
 }
 \description{
 Construct tidied data frames showing survival curves over time.


### PR DESCRIPTION
Running tidy() on a ‘survfit’ or ‘survfitms’ object which
didn’t have a confidence interval (i.e. was created with
conf.type="none" or conf.int=FALSE) resulted in an error message.
This commit fixes this bug (fixes #305). Now the confidence
interval is only included in the tidy data frame if the
‘survfit’ object actually includes a confidence interval.
Also, the order of the confidence limit in the resulting
object is changed, from ‘conf.high, conf.low’ to the more
natural ‘conf.low, conf.high’, for consistency with other
broom functions (e.g. tidy.lm and glance.survfit).

A similar bug was present when running glance() on a ‘survfit’
object which didn’t have a confidence interval. It resulted
in the median and standard error of the restricted mean being
mislabelled as the upper and lower confidence limits. This
commit also fixes this bug (fixed #304).

The documentation for the two functions is also updated
to reflect the changes.