### PR TITLE
Modelgenerics S4 redefinition hotfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -136,5 +136,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1.9000
 Remotes: 
-    topepo/modelgenerics,
+    topepo/modelgenerics@c14b7a,
     alexpghayes/modeltests


### PR DESCRIPTION
Point dev version of broom to an older version of `modelgenerics` where tidy, glance and augment are exported as S3 methods.