### PR TITLE
Remove reshape2 dependency from tidy.dist and add tests.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,7 @@ Authors@R: c(
     person("Paul", "PJ", email = "pjpaul.stephens@gmail.com", role = "ctb"),
     person("Ben", "Schneider", email = "benjamin.julius.schneider@gmail.com", role = "ctb"),
     person("Patrick", "Kennedy", email = "pkqstr@protonmail.com", role = "ctb"),
-    person("Nic", "Crane", email = "thisisnic@gmail.com", role = "ctb"),
-    person("Lily", "Medina", email = "lilymiru@gmail.com", role = "ctb"))
+    person("Brian", "Fannin", email = "captain@pirategrunt.com", role = "ctb"))
 Maintainer: David Robinson <admiral.david@gmail.com>
 Description: Summarizes key information about statistical objects in tidy
     tibbles. This makes it easy to report results, create plots and consistently

--- a/R/list-xyz-tidiers.R
+++ b/R/list-xyz-tidiers.R
@@ -39,10 +39,9 @@ tidy_xyz <- function(x, ...) {
     )
   }
   
-  d <- reshape2::melt(x$z)
-  names(d) <- c("x", "y", "z")
-  # get coordinates
-  d$x <- x$x[d$x]
-  d$y <- x$y[d$y]
-  as_tibble(d)
+  d <- as_tibble(x$z)
+  names(d) <- x$y
+  d$x <- x$x
+  tidyr::gather(d, y, z, -x)
+
 }

--- a/R/stats-tidiers.R
+++ b/R/stats-tidiers.R
@@ -70,19 +70,19 @@ tidy.dist <- function(x, diagonal = attr(x, "Diag"),
                       upper = attr(x, "Upper"), ...) {
   m <- as.matrix(x)
 
-  ret <- reshape2::melt(m,
-    varnames = c("item1", "item2"),
-    value.name = "distance"
-  )
-
+  ret <- as_tibble(m, rownames = 'item1')
+  ret <- tidyr::gather(ret, item2, distance, -item1)
+  
   if (!upper) {
     ret <- ret[!upper.tri(m), ]
   }
 
   if (!diagonal) {
-    ret <- filter(ret, item1 != item2)
+    ret <- dplyr::filter(ret, item1 != item2)
   }
-  as_tibble(ret)
+  
+  ret
+
 }
 
 

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -15,8 +15,21 @@ test_that("tidy.density", {
 test_that("tidy.dist", {
   iris_dist <- dist(t(iris[, 1:4]))
   td <- tidy(iris_dist)
+  td_upper <- tidy(iris_dist, upper = TRUE)
+  td_diag <- tidy(iris_dist, diagonal = TRUE)
+  td_all <- tidy(iris_dist, upper = TRUE, diagonal = TRUE)
   
   check_arguments(tidy.dist)
   check_tidy_output(td)
   check_dims(td, 6, 3)
+  
+  check_tidy_output(td_upper)
+  check_dims(td_upper, 12, 3)
+  
+  check_tidy_output(td_diag)
+  check_dims(td_diag, 10, 3)
+  
+  check_tidy_output(td_all)
+  check_dims(td_all, 16, 3)
+  
 })


### PR DESCRIPTION
I am using `tidyr::gather` in the `tidy.dist()` function and have also qualified the use of `filter()` as `dplyr::filter()`. I did not include roxygen comments to import these functions as there were not similar comments for functions like `as_tibble()`. I think the various package dependencies and imports should take care of that.

There is at least one test which failed, but it comes from the file `test-mass-rlm.R`. I pulled from the master branch just before testing.