### PR TITLE
tidy.plm: add argument quick

### DIFF
--- a/R/plm-tidiers.R
+++ b/R/plm-tidiers.R
@@ -4,6 +4,7 @@
 #' @param x A `plm` objected returned by [plm::plm()].
 #' @template param_confint
 #' @template param_exponentiate
+#' @template param_quick
 #' @template param_unused_dots
 #' 
 #' @evalRd return_tidy(regression = TRUE)
@@ -30,10 +31,10 @@
 #' @seealso [tidy()], [plm::plm()], [tidy.lm()]
 #' @family plm tidiers
 tidy.plm <- function(x, conf.int = FALSE, conf.level = .95,
-                     exponentiate = FALSE, ...) {
+                     exponentiate = FALSE, quick = FALSE, ...) {
   tidy.lm(x,
     conf.int = conf.int, conf.level = conf.level,
-    exponentiate = exponentiate
+    exponentiate = exponentiate, quick = quick
   )
 }
 


### PR DESCRIPTION
`tidy.plm` does not have the standard `quick` argument? I added it explicitly (also in doc, needs to be re-run?) though another approach would be to simply pass the ..., which for now is ignored?

Thanks!