### PR TITLE
lfe-tidyr: allow for multiple response

### DIFF
--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -148,7 +148,7 @@ augment.felm <- function(x, data = model.frame(x), ...) {
   
   if(has_multi_response) {
     stop(
-      "Glance does not support linear models with multiple responses.",
+      "Augment does not support linear models with multiple responses.",
       call. = FALSE
     )  
   } 

--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -47,12 +47,30 @@
 #' @seealso [tidy()], [lfe::felm()]
 tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, quick = FALSE, ...) {
 
+  has_multi_response <- length(x$lhs) > 1
+  
   if(quick) {
     co <- stats::coef(x)
-    ret <- data_frame(term = names(co), estimate = unname(co))
+    if(has_multi_response) {
+      ret <- co <- stats::coef(x) %>%  
+        as_tibble(rownames = "term") %>% 
+        tidyr::gather(response, estimate, -term) %>% 
+        select(response, term, estimate) 
+    } else {
+      ret <- data_frame(term = names(co), estimate = unname(co))  
+    }
+    
   } else {
     nn <- c("estimate", "std.error", "statistic", "p.value")
-    ret <- fix_data_frame(stats::coef(summary(x)), nn)  
+    if(has_multi_response) {
+      ret <-  map_df(x$lhs, function(y) stats::coef(summary(x, lhs = y)) %>% 
+               fix_data_frame(nn) %>% 
+               mutate(response = y)) %>% 
+        select(response, everything())
+      
+    } else {
+      ret <- fix_data_frame(stats::coef(summary(x)), nn)  
+    }
   }
   
 
@@ -66,14 +84,34 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, quick =
   if (fe) {
     ret <- mutate(ret, N = NA, comp = NA)
     if(quick) {
-      ret_fe <- lfe::getfe(x) %>%
-        select(effect, obs, comp) %>%
-        fix_data_frame(c("estimate",  "N", "comp")) 
+      ret_fe_prep <- lfe::getfe(x) %>% 
+        tibble::rownames_to_column(var = "term") 
+      if(has_multi_response) ret_fe_prep <-  ret_fe_prep %>% 
+          tidyr::gather(response, effect, starts_with("effect.")) %>% 
+          mutate(response = stringr::str_remove(response, "effect."))
+      
+      ret_fe <-  ret_fe_prep%>%
+        select(contains("response"), term, effect, obs, comp) %>%
+        rename(N = obs,
+               estimate = effect)
     } else {
       nn <- c("estimate", "std.error", "N", "comp")
-      ret_fe <- lfe::getfe(x, se = TRUE, bN = 100) %>%
-        select(effect, se, obs, comp) %>%
-        fix_data_frame(nn) %>%
+      ret_fe_prep <- lfe::getfe(x, se = TRUE, bN = 100) %>% 
+        tibble::rownames_to_column(var = "term") %>% 
+        select(term, contains("effect"),  contains("se"), obs, comp) %>% # effect and se are multiple if multiple y
+        rename(N=obs) 
+      
+      if(has_multi_response) {
+        ret_fe_prep <-  ret_fe_prep  %>% 
+          tidyr::gather(key = "stat_resp", value, starts_with("effect."), starts_with("se.")) %>% 
+          tidyr::separate(col = "stat_resp", c("stat", "response"), sep="\\.") %>% 
+          tidyr::spread(key = "stat", value) 
+        # nn <-  c("response", nn)
+      }
+      ret_fe <-  ret_fe_prep %>%
+        rename(estimate = effect, std.error = se) %>% 
+        select(contains("response"), everything()) %>%
+        # fix_data_frame(nn) %>%
         mutate(statistic = estimate / std.error) %>%
         mutate(p.value = 2 * (1 - stats::pt(statistic, df = N)))  
     }
@@ -106,8 +144,18 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, quick =
 #' @family felm tidiers
 #' @seealso [augment()], [lfe::felm()]
 augment.felm <- function(x, data = model.frame(x), ...) {
+  has_multi_response <- length(x$lhs) > 1
+  
+  if(has_multi_response) {
+    stop(
+      "Glance does not support linear models with multiple responses.",
+      call. = FALSE
+    )  
+  } 
   df <- as_broom_tibble(data)
   mutate(df, .fitted = x$fitted.values, .resid = x$residuals)
+  
+  
 }
 
 #' @templateVar class felm
@@ -127,6 +175,15 @@ augment.felm <- function(x, data = model.frame(x), ...) {
 #'
 #' @export
 glance.felm <- function(x, ...) {
+  
+  has_multi_response <- length(x$lhs) > 1
+  
+  if(has_multi_response) {
+    stop(
+      "Glance does not support linear models with multiple responses.",
+      call. = FALSE
+    )  
+  } 
   ret <- with(
     summary(x),
     tibble(

--- a/man/tidy.felm.Rd
+++ b/man/tidy.felm.Rd
@@ -7,7 +7,7 @@
 \title{Tidy a(n) felm object}
 \usage{
 \method{tidy}{felm}(x, conf.int = FALSE, conf.level = 0.95,
-  fe = FALSE, ...)
+  fe = FALSE, quick = FALSE, ...)
 }
 \arguments{
 \item{x}{A \code{felm} object returned from \code{\link[lfe:felm]{lfe::felm()}}.}
@@ -21,6 +21,10 @@ Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
 
 \item{fe}{Logical indicating whether or not to include estimates of
 fixed effects. Defaults to \code{FALSE}.}
+
+\item{quick}{Logical indiciating if the only the \code{term} and \code{estimate}
+columns should be returned. Often useful to avoid time consuming
+covariance and standard error calculations. Defaults to \code{FALSE}.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -17,6 +17,8 @@ df <- data.frame(
 
 fit <- lfe::felm(v2 ~ v3, df)
 fit2 <- lfe::felm(v2 ~ v3 | id + v1, df, na.action = na.exclude)
+fit_multi <- lfe::felm(v1 + v2 ~ v3 , df)
+
 
 form <- v2 ~ v4
 fit_form <- lfe::felm(form, df)  # part of a regression test
@@ -37,6 +39,9 @@ test_that("tidy.felm", {
   td4 <- tidy(fit_form)
   td4_quick <- tidy(fit_form, quick = TRUE)
   
+  td_multi <- tidy(fit_multi)
+  td_multi_quick <- tidy(fit_multi, quick = TRUE)
+  
   check_tidy_output(td)
   check_tidy_output(td_quick)
   check_tidy_output(td2)
@@ -45,8 +50,12 @@ test_that("tidy.felm", {
   check_tidy_output(td3_quick)
   check_tidy_output(td4)
   check_tidy_output(td4_quick)
+  check_tidy_output(td_multi)
+  check_tidy_output(td_multi_quick)
   
   check_dims(td, 2, 5)
+  
+  expect_equal(tidy(fit_multi)[3:4, -1], tidy(fit))
 })
 
 test_that("glance.felm", {
@@ -55,6 +64,8 @@ test_that("glance.felm", {
   
   check_glance_outputs(gl, gl2)
   check_dims(gl, expected_cols = 7)
+  
+  expect_error(glance(fit_multi), "Glance does not support linear models with multiple responses.")
 })
 
 test_that("augment.felm", {
@@ -76,4 +87,5 @@ test_that("augment.felm", {
     model = fit_form,
     data = df
   )
+  expect_error(augment(fit_multi), "Glance does not support linear models with multiple responses.")
 })

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -87,5 +87,5 @@ test_that("augment.felm", {
     model = fit_form,
     data = df
   )
-  expect_error(augment(fit_multi), "Glance does not support linear models with multiple responses.")
+  expect_error(augment(fit_multi), "Augment does not support linear models with multiple responses.")
 })


### PR DESCRIPTION
Hi

Like lm(), `felm()` can compute multi-responses models, using `lfe::felm(v1 + v2 ~ v3 , df)`. `tidy()` will fail as `summary()` on such an output returns: *Error in summary.felm(x) : Please specify lhs=[one of v1,v2]* 

This pull request calls summary() for each response, then binds it so that tidy() work on it. For `glance()` and `augment()`, it follows the behaviour of `glance.mlm`, that will not return anything. I am not sure whether this is a long-term strategy of the package, or not? There are clearly cases where allowing for multiple responses at that level would be great!

Thanks!
