### PR TITLE
Adapt to dev tibble

### DIFF
--- a/R/base-tidiers.R
+++ b/R/base-tidiers.R
@@ -14,7 +14,7 @@
 #' 
 #' @examples
 #'
-#' tab <- with(airquality, table(cut(Temp, quantile(Temp)), Month))
+#' tab <- with(airquality, table(Temp = cut(Temp, quantile(Temp)), Month))
 #' tidy(tab)
 #'
 #' @seealso [as_tibble.table()]

--- a/R/lavaan-tidiers.R
+++ b/R/lavaan-tidiers.R
@@ -132,9 +132,8 @@ glance.lavaan <- function(x, ...) {
           "cfi"
         )
     ) %>%
-    as_tibble() %>%
-    tibble::rownames_to_column(var = "term") %>%
-    spread(., term, value) %>%
+    tibble::enframe(name = "term") %>%
+    spread(term, value) %>%
     bind_cols(
       tibble(
         converged = x@Fit@converged,

--- a/R/sp-tidiers.R
+++ b/R/sp-tidiers.R
@@ -66,8 +66,8 @@ tidy.Polygons <- function(x, ...) {
 #' @export
 #' @method tidy Polygon
 tidy.Polygon <- function(x, ...) {
+  sp::coordnames(x) <- c("long", "lat")
   df <- as_tibble(x@coords)
-  names(df) <- c("long", "lat")
   df$order <- 1:nrow(df)
   df$hole <- x@hole
   df
@@ -103,8 +103,8 @@ tidy.Lines <- function(x, ...) {
 #' @export
 #' @method tidy Line
 tidy.Line <- function(x, ...) {
+  sp::coordnames(x) <- c("long", "lat")
   df <- as_tibble(x@coords)
-  names(df) <- c("long", "lat")
   df$order <- 1:nrow(df)
   unrowname(df)
 }

--- a/R/stats-tidiers.R
+++ b/R/stats-tidiers.R
@@ -16,7 +16,7 @@
 #' @seealso [tidy()], [stats::ftable()]
 #' @family stats tidiers
 tidy.ftable <- function(x, ...) {
-  as_tibble(x)
+  as_tibble(as.table(x))
 }
 
 #' @templateVar class density

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,13 @@ init:
 install:
   ps: Bootstrap
 
+environment:
+  global:
+    USE_RTOOLS: true
+
+cache:
+  - C:\RLibrary
+
 # Adapt as necessary starting from here
 
 build_script:

--- a/man/tidy.table.Rd
+++ b/man/tidy.table.Rd
@@ -39,7 +39,7 @@ returned object \link[tibble:tibble]{tibble::tibble} class.
 }
 \examples{
 
-tab <- with(airquality, table(cut(Temp, quantile(Temp)), Month))
+tab <- with(airquality, table(Temp = cut(Temp, quantile(Temp)), Month))
 tidy(tab)
 
 }

--- a/tests/testthat/test-base.R
+++ b/tests/testthat/test-base.R
@@ -30,7 +30,7 @@ test_that("tidy.summary", {
 
 
 test_that("tidy.table", {
-  tab <- with(airquality, table(cut(Temp, quantile(Temp)), Month))
+  tab <- with(airquality, table(Temp = cut(Temp, quantile(Temp)), Month))
   td <- tidy(tab)
   check_tidy_output(td)
   check_dims(td, 20, 3)


### PR DESCRIPTION
Resuming https://github.com/tidymodels/broom/pull/534 here.

sp-tidiers main theme: apply column names before coercing to tibble

lavaan-tiders: use `enframe()`, which is unambiguously requesting a column, instead of `as_tibble()` on a vector

base tidiers: I gather these are on the path to deprecation / removal, since they are basically just `as_tibble()`. So I altered your tests and examples enough that you aren't testing our edge cases. I also coerce `ftable` objects to `table` so we only have to worry about one thing.