### PR TITLE
Install Rtools and cache the library on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,13 @@ init:
 install:
   ps: Bootstrap
 
+environment:
+  global:
+    USE_RTOOLS: true
+
+cache:
+  - C:\RLibrary
+
 # Adapt as necessary starting from here
 
 build_script:


### PR DESCRIPTION
I think this might clear up some of your appveyor failures and possibly speed things up. With this many dependencies, it seems likely that *something* is going to need compilation.

If this seems good, you might want to port to the 0.5.1 branch as well.