### PR TITLE
tidy.mlm: fix case with quick = TRUE, giving from response info

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@ in the augment method for the chi sq test, .residuals column was renamed to .res
 - Added `data` argument to `augment()` generic (did this happen?)
 - tidy.kmeans now defaults to using variable names in output columns
 - Bug fix for tidy.ridgelm returning inconsistent columns (#532)
+- Correct output for  `tidy.mlm(, quick=TRUE)`, add tests (#539 by @MatthieuStigler)
+
 
 ## Deprecations
 

--- a/R/stats-lm-tidiers.R
+++ b/R/stats-lm-tidiers.R
@@ -73,7 +73,8 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = .95,
   if (quick) {
     co <- stats::coef(x)
     if (inherits(x,'mlm')) {
-      ret <- data.frame(response = colnames(co), term = rownames(co), 
+      ret <- data.frame(response = rep(colnames(co), each = nrow(co)),
+                        term = rep(rownames(co), times = ncol(co)),
                         estimate = as.numeric(co), stringsAsFactors = FALSE)
     } else {
       ret <- data.frame(term = names(co), estimate = unname(co),

--- a/tests/testthat/test-stats-lm.R
+++ b/tests/testthat/test-stats-lm.R
@@ -180,7 +180,11 @@ test_that("tidy.mlm works", {
   expect_equal(td2$term, rep(c("(Intercept)", "x1","x2"),2))
   expect_equal(td$response, rep_each(c("y1", "y2"), 2))
   expect_equal(td2$response, rep_each(c("y1", "y2"), 3))
-
+  expect_equal(tdq$term, rep(c("(Intercept)", "x1"),2))
+  expect_equal(tdq2$term, rep(c("(Intercept)", "x1", "x2"),2))
+  expect_equal(tdq$response, rep_each(c("y1", "y2"), 2))
+  expect_equal(tdq2$response, rep_each(c("y1", "y2"), 3))
+  
   expect_warning(
     tidy(fit2, exponentiate = TRUE),
     regexp = paste(


### PR DESCRIPTION
`tidy.mlm(., quick = TRUE)` was giving wrong columns infos for response (see below). corrected

``` r
library(broom)
packageVersion("broom")
#> [1] '0.5.0.9001'
mod_mlm <- lm(cbind(mpg, qsec) ~ wt +drat, data = mtcars)
coef(mod_mlm)
#>                   mpg       qsec
#> (Intercept) 30.290370 19.9702437
#> wt          -4.782890 -0.4069888
#> drat         1.442491 -0.2258015
# ok
tidy(mod_mlm)
#> # A tibble: 6 x 6
#>   response term        estimate std.error statistic    p.value
#>   <chr>    <chr>          <dbl>     <dbl>     <dbl>      <dbl>
#> 1 mpg      (Intercept)   30.3       7.32      4.14  0.000274  
#> 2 mpg      wt            -4.78      0.797    -6.00  0.00000159
#> 3 mpg      drat           1.44      1.46      0.989 0.331     
#> 4 qsec     (Intercept)   20.0       4.36      4.58  0.0000822 
#> 5 qsec     wt            -0.407     0.475    -0.856 0.399     
#> 6 qsec     drat          -0.226     0.870    -0.260 0.797
# not ok
tidy(mod_mlm, quick = TRUE)
#> # A tibble: 6 x 3
#>   response term        estimate
#>   <chr>    <chr>          <dbl>
#> 1 mpg      (Intercept)   30.3  
#> 2 qsec     wt            -4.78 
#> 3 mpg      drat           1.44 
#> 4 qsec     (Intercept)   20.0  
#> 5 mpg      wt            -0.407
#> 6 qsec     drat          -0.226
```

<sup>Created on 2018-11-21 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>