### PR TITLE
fix ordinal+scale bug

### DIFF
--- a/R/ordinal-tidiers.R
+++ b/R/ordinal-tidiers.R
@@ -124,10 +124,13 @@ process_clm <- function(ret, x, conf.int = FALSE, conf.level = .95,
   }
 
   ret$estimate <- trans(ret$estimate)
-  ret$coefficient_type <- ""
-  ret[ret$term %in% names(x$alpha), "coefficient_type"] <- "alpha"
-  ret[ret$term %in% names(x$beta), "coefficient_type"] <- "beta"
-  ret[ret$term %in% names(x$zeta), "coefficient_type"] <- "zeta"
+  ## make sure original order hasn't changed
+  if (!identical(ret$term,c(names(x$alpha),names(x$beta),names(x$zeta)))) {
+      stop("row order changed; please contact maintainers")
+  }
+  ret$coefficient_type <- rep(c("alpha","beta","zeta"),
+                              vapply(x[c("alpha","beta","zeta")],
+                                     length, numeric(1)))
   as_tibble(ret)
 }
 

--- a/tests/testthat/test-ordinal.R
+++ b/tests/testthat/test-ordinal.R
@@ -7,6 +7,9 @@ skip_if_not_installed("ordinal")
 library(ordinal)
 
 fit <- clm(rating ~ temp * contact, data = wine)
+fit_sc <- clm(rating ~ temp + contact,
+               scale = ~ temp + contact,
+               data = wine)
 mfit <- clmm(rating ~ temp + contact + (1 | judge), data = wine)
 
 test_that("ordinal tidier arguments", {
@@ -34,6 +37,12 @@ test_that("tidy.clm", {
                label = "'term' column in tidy output with `conf.int = FALSE`",
                expected.label = "'term' column in tidy output with `conf.int = TRUE`",
                info = "The terms (and their order) should be unaffected by whether `conf.int` = TRUE or `conf.int` = FALSE.")
+})
+
+test_that("tidy.clm works with scale parameter", {
+    tt <- tidy(fit_sc)
+    expect_equal(tt$coefficient_type, rep(c("alpha","beta","zeta"),
+                                          c(4,2,2)))
 })
 
 test_that("glance.clm", {


### PR DESCRIPTION
current version of the `ordinal` tidiers uses a naive (and wrong) approach to distinguish parameters that determine the intercept (`alpha`); effects of parameters on the location (`beta`); effects of parameters on the scale (`zeta`).  It fails if there are identical terms in the location and scale models, which is typical.

Might also be worth considering a **breaking** change to label the coefficient types "intercept", "location", and "scale" instead of "alpha", "beta", and "zeta" ...

