### PR TITLE
Fix tidy.survreg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Authors@R: c(
     person("Matt", "Lehman", role = "ctb"),
     person("Bill", "Denney", email = "wdenney@humanpredictions.com", role = "ctb", comment = c(ORCID = "0000-0002-5759-428X")),
     person("Nic", "Crane", role = "ctb"))
-
 Maintainer: David Robinson <admiral.david@gmail.com>
 Description: Summarizes key information about statistical objects in tidy
     tibbles. This makes it easy to report results, create plots and consistently

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,9 @@ Authors@R: c(
     person("Brian", "Fannin", email = "captain@pirategrunt.com", role = "ctb"),
     person("Jason", "Muhlenkamp", email = "jason.muhlenkamp@gmail.com", role = "ctb"),
     person("Matt", "Lehman", role = "ctb"),
-    person("Bill", "Denney", email = "wdenney@humanpredictions.com", role = "ctb", comment = c(ORCID = "0000-0002-5759-428X")))
+    person("Bill", "Denney", email = "wdenney@humanpredictions.com", role = "ctb", comment = c(ORCID = "0000-0002-5759-428X")),
+    person("Nic", "Crane", role = "ctb"))
+
 Maintainer: David Robinson <admiral.david@gmail.com>
 Description: Summarizes key information about statistical objects in tidy
     tibbles. This makes it easy to report results, create plots and consistently

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ in the augment method for the chi sq test, .residuals column was renamed to .res
 
 - augment
 - tidy.lsmobj gains a `conf.int` argument.
+- tidy.survreg gains a `conf.int`.
 - Add `tidy.regsubsets()` for best subsets linear regression from the `leaps` package
 - All `conf.int` arguments now default to `FALSE`.
 - All `conf.level` arguments now default to `TRUE`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ in the augment method for the chi sq test, .residuals column was renamed to .res
 
 - augment
 - tidy.lsmobj gains a `conf.int` argument.
-- tidy.survreg gains a `conf.int`.
+- tidy.survreg gains a `conf.int` argument.
 - Add `tidy.regsubsets()` for best subsets linear regression from the `leaps` package
 - All `conf.int` arguments now default to `FALSE`.
 - All `conf.level` arguments now default to `TRUE`.

--- a/R/survival-survreg-tidiers.R
+++ b/R/survival-survreg-tidiers.R
@@ -2,7 +2,8 @@
 #' @template title_desc_tidy
 #'
 #' @param x An `survreg` object returned from [survival::survreg()].
-#' @param conf.level confidence level for CI
+#' @param conf.int Logical indicating whether or not to include a confidence interval in the tidied output. Defaults to FALSE.
+#' @param conf.level The confidence level to use for the confidence interval if conf.int = TRUE. Must be strictly greater than 0 and less than 1. Defaults to 0.95, which corresponds to a 95 percent confidence interval.
 #' @template param_unused_dots
 #' 
 #' @evalRd return_tidy(regression = TRUE)
@@ -17,11 +18,12 @@
 #'   dist = "exponential"
 #' )
 #'
-#' td <- tidy(sr)
+#' tidy(sr)
 #' augment(sr, ovarian)
 #' glance(sr)
 #'
 #' # coefficient plot
+#' td <- tidy(sr, conf.int = TRUE)
 #' library(ggplot2)
 #' ggplot(td, aes(estimate, term)) + 
 #'   geom_point() +
@@ -34,17 +36,20 @@
 #' @family survreg tidiers
 #' @family survival tidiers
 #' 
-tidy.survreg <- function(x, conf.level = .95, ...) {
+tidy.survreg <- function(x, conf.level = .95, conf.int = FALSE, ...) {
   s <- summary(x)
   nn <- c("estimate", "std.error", "statistic", "p.value")
   ret <- fix_data_frame(s$table, newnames = nn)
-  ret
   
-  # add confidence interval
-  ci <- stats::confint(x, level = conf.level)
-  colnames(ci) <- c("conf.low", "conf.high")
-  ci <- fix_data_frame(ci)
-  as_tibble(merge(ret, ci, all.x = TRUE, sort = FALSE))
+  if(conf.int){
+    # add confidence interval
+    ci <- stats::confint(x, level = conf.level)
+    colnames(ci) <- c("conf.low", "conf.high")
+    ci <- fix_data_frame(ci)
+    ret <- as_tibble(merge(ret, ci, all.x = TRUE, sort = FALSE))
+  }
+  
+  ret
 }
 
 

--- a/man/tidy.survreg.Rd
+++ b/man/tidy.survreg.Rd
@@ -5,12 +5,14 @@
 \alias{survreg_tidiers}
 \title{Tidy a(n) survreg object}
 \usage{
-\method{tidy}{survreg}(x, conf.level = 0.95, ...)
+\method{tidy}{survreg}(x, conf.level = 0.95, conf.int = FALSE, ...)
 }
 \arguments{
 \item{x}{An \code{survreg} object returned from \code{\link[survival:survreg]{survival::survreg()}}.}
 
-\item{conf.level}{confidence level for CI}
+\item{conf.level}{The confidence level to use for the confidence interval if conf.int = TRUE. Must be strictly greater than 0 and less than 1. Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
+
+\item{conf.int}{Logical indicating whether or not to include a confidence interval in the tidied output. Defaults to FALSE.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be
@@ -40,11 +42,12 @@ sr <- survreg(
   dist = "exponential"
 )
 
-td <- tidy(sr)
+tidy(sr)
 augment(sr, ovarian)
 glance(sr)
 
 # coefficient plot
+td <- tidy(sr, conf.int = TRUE)
 library(ggplot2)
 ggplot(td, aes(estimate, term)) + 
   geom_point() +
@@ -74,8 +77,8 @@ Other survival tidiers: \code{\link{augment.coxph}},
 \concept{survreg tidiers}
 \value{
 A \code{\link[tibble:tibble]{tibble::tibble()}} with columns:
-  \item{conf.high}{Upper bound on the confidence interval for the estimate.}
-  \item{conf.low}{Lower bound on the confidence interval for the estimate.}
+  \item{conf.high}{The upper end of a confidence interval for the term under consideration. Included only if `conf.int = TRUE`.}
+  \item{conf.low}{The lower end of a confidence interval for the term under consideration. Included only if `conf.int = TRUE`.}
   \item{estimate}{The estimated value of the regression term.}
   \item{p.value}{The two-sided p-value associated with the observed statistic.}
   \item{statistic}{The value of a T-statistic to use in a hypothesis that the regression term is non-zero.}

--- a/tests/testthat/test-survival-survreg.R
+++ b/tests/testthat/test-survival-survreg.R
@@ -11,17 +11,24 @@ sr <- survreg(Surv(futime, fustat) ~ ecog.ps + rx, ovarian,
 )
 
 test_that("survreg tidier arguments", {
-  check_arguments(tidy.survreg, strict = FALSE)
+  check_arguments(tidy.survreg)
   check_arguments(glance.survreg)
   check_arguments(augment.survreg)
 })
 
-
 test_that("tidy.survreg", {
   td <- tidy(sr)
+  td2 <- tidy(sr, conf.int = TRUE)
+  
   check_tidy_output(td)
-  check_dims(td, 3, 7)
+  check_tidy_output(td2)
+  
+  check_dims(td, 3, 5)
+  check_dims(td2, 3, 7)
+  
   expect_equal(td$term, c("(Intercept)", "ecog.ps", "rx"))
+  expect_equal(td2$term, c("(Intercept)", "ecog.ps", "rx"))
+  
 })
 
 test_that("glance.survreg", {


### PR DESCRIPTION
The test for `tidy.survreg` was failing the  `check_arguments` test because `tidy.survreg` had a `conf.level` argument but no `conf.int` argument.  I made the following changes:

* Updated `tidy.survreg` to also include a `conf.int` argument which is set to FALSE by default (note: previously, confidence intervals were always reported).
* Added this to NEWS as this will be a potentially breaking change.
* Updated the documentation for `tidy.survreg` to include this new parameter.
* Updated the examples for `tidy.survreg` as the coefficient plot needs a `tidy.survreg` object which has been created with `conf.int` set to TRUE.
* Updated the tests for `tidy.survreg` to run `check_arguments` with strict set to TRUE (the default) and also modified the testing of the values to test both when conf.int is set to TRUE or set to FALSE.

Happy to make further changes if any of this need altering though! 