### PR TITLE
change match.arg to rlang::arg_match

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Authors@R: c(
     person("Jason", "Muhlenkamp", email = "jason.muhlenkamp@gmail.com", role = "ctb"),
     person("Matt", "Lehman", role = "ctb"),
     person("Bill", "Denney", email = "wdenney@humanpredictions.com", role = "ctb", comment = c(ORCID = "0000-0002-5759-428X")),
-    person("Nic", "Crane", role = "ctb"))
+    person("Nic", "Crane", role = "ctb"),
+    person("Andrew", "Bates", role = "ctb"))
 Maintainer: David Robinson <admiral.david@gmail.com>
 Description: Summarizes key information about statistical objects in tidy
     tibbles. This makes it easy to report results, create plots and consistently

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ in the augment method for the chi sq test, .residuals column was renamed to .res
 - `tidy_optim()` provides the standard error if the Hessian is present. (#529 by @billdenney)
 - `tidy.htest()` column names are now run through `make.names()` to ensure syntactic correctness (#549 by @karissawhiting) 
 - Added method `tidy.lm.beta()` to tidy `lm.beta` class models (#545 by @mattle24)
+- Use `rlang::arg_match()` for more informative errors on argument mismatches.
 
 
 ## Deprecations

--- a/R/brms-tidiers.R
+++ b/R/brms-tidiers.R
@@ -78,7 +78,7 @@ tidy.brmsfit <- function(x, parameters = NA,
   .Deprecated()
   use_par_type <- anyNA(parameters)
   if (use_par_type) {
-    par_type <- match.arg(par_type)
+    par_type <- rlang::arg_match(par_type)
     if (par_type == "all") {
       parameters <- NA
     } else if (par_type == "non-varying") {

--- a/R/joinerml-tidiers.R
+++ b/R/joinerml-tidiers.R
@@ -65,7 +65,7 @@
 #' 
 tidy.mjoint <- function(x, component = "survival", conf.int = FALSE,
                         conf.level = 0.95,  boot_se = NULL, ...) {
-  component <- match.arg(component, c("survival", "longitudinal"))
+  component <- rlang::arg_match(component, c("survival", "longitudinal"))
   if (!is.null(boot_se)) {
     if (!inherits(x = boot_se, "bootSE")) 
       stop("`boot_se` argument must be a `bootSE` object.", call. = FALSE)

--- a/R/mass-polr-tidiers.R
+++ b/R/mass-polr-tidiers.R
@@ -60,6 +60,6 @@ glance.polr <- function(x, ...) {
 #' @export
 augment.polr <- function(x, data = model.frame(x), newdata = NULL,
                          type.predict = c("probs", "class"), ...) {
-  type <- match.arg(type.predict)
+  type <- rlang::arg_match(type.predict)
   augment_columns(x, data, newdata, type = type.predict)
 }

--- a/R/mcmc-tidiers.R
+++ b/R/mcmc-tidiers.R
@@ -38,7 +38,7 @@ tidyMCMC <- function(x,
     ss <- ss[, pars]
   }
 
-  estimate.method <- match.arg(estimate.method, c("mean", "median"))
+  estimate.method <- rlang::arg_match(estimate.method, c("mean", "median"))
   m <- switch(estimate.method,
     mean = colMeans(ss),
     median = apply(ss, 2, stats::median)
@@ -51,7 +51,7 @@ tidyMCMC <- function(x,
   if (conf.int) {
     levs <- c((1 - conf.level) / 2, (1 + conf.level) / 2)
 
-    conf.method <- match.arg(conf.method, c("quantile", "HPDinterval"))
+    conf.method <- rlang::arg_match(conf.method, c("quantile", "HPDinterval"))
     ci <- switch(conf.method,
       quantile = t(apply(ss, 2, stats::quantile, levs)),
       coda::HPDinterval(coda::as.mcmc(ss), prob = conf.level)

--- a/R/nlme-tidiers.R
+++ b/R/nlme-tidiers.R
@@ -59,7 +59,7 @@
 #' @export
 tidy.lme <- function(x, effects = "random", ...) {
   .Deprecated()
-  effects <- match.arg(effects, c("random", "fixed"))
+  effects <- rlang::arg_match(effects, c("random", "fixed"))
   if (effects == "fixed") {
     # return tidied fixed effects rather than random
     ret <- summary(x)$tTable

--- a/R/ordinal-tidiers.R
+++ b/R/ordinal-tidiers.R
@@ -89,7 +89,7 @@ tidy.clm <- function(x, conf.int = FALSE, conf.level = .95,
     )
     return(process_clm(ret, x, conf.int = FALSE, exponentiate = exponentiate))
   }
-  conf.type <- match.arg(conf.type)
+  conf.type <- rlang::arg_match(conf.type)
   co <- coef(summary(x))
   nn <- c("estimate", "std.error", "statistic", "p.value")
   ret <- fix_data_frame(co, nn[seq_len(ncol(co))])
@@ -162,6 +162,6 @@ glance.clmm <- glance.clm
 #' @export
 augment.clm <- function(x, data = model.frame(x), newdata = NULL,
                         type.predict = c("prob", "class"), ...) {
-  type.predict <- match.arg(type.predict)
+  type.predict <- rlang::arg_match(type.predict)
   augment_columns(x, data, newdata, type = type.predict)
 }

--- a/R/rstanarm-tidiers.R
+++ b/R/rstanarm-tidiers.R
@@ -83,7 +83,7 @@ tidy.stanreg <- function(x,
                          ...) {
   .Deprecated()
   parameters <-
-    match.arg(parameters,
+    rlang::arg_match(parameters,
       several.ok = TRUE,
       choices = c(
         "non-varying", "varying",

--- a/R/stats-glm-tidiers.R
+++ b/R/stats-glm-tidiers.R
@@ -47,8 +47,8 @@ augment.glm <- function(x,
   type.residuals = c("deviance", "pearson"),
   se_fit = FALSE, ...) {
   
-  type.predict <- match.arg(type.predict)
-  type.residuals <- match.arg(type.residuals)
+  type.predict <- rlang::arg_match(type.predict)
+  type.residuals <- rlang::arg_match(type.residuals)
   
   df <- if (is.null(newdata)) data else newdata
   df <- as_broom_tibble(df)

--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -92,7 +92,7 @@ tidy.prcomp <- function(x, matrix = "u", ...) {
   }
 
   MATRIX <- c("rotation", "x", "variables", "samples", "v", "u", "pcs", "d")
-  matrix <- match.arg(matrix, MATRIX)
+  matrix <- rlang::arg_match(matrix, MATRIX)
 
   ncomp <- NCOL(x$rotation)
   if (matrix %in% c("pcs", "d")) {

--- a/R/tseries-tidiers.R
+++ b/R/tseries-tidiers.R
@@ -60,7 +60,7 @@ tidy.garch <- function(x, ...) {
 #' @family garch tidiers
 #' @seealso [glance()], [tseries::garch()], []
 glance.garch <- function(x, test = c("box-ljung-test", "jarque-bera-test"), ...) {
-  test <- match.arg(test)
+  test <- rlang::arg_match(test)
   s <- summary(x)
   ret <- garch_glance_helper(s, test, ...)
   ret <- finish_glance(ret, x)


### PR DESCRIPTION
Calls to match.arg changed to rlang::arg_match closing #553.

Please bear with me if there is anything else I was supposed to do. This is my first pull request!