### PR TITLE
fixed link to contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ valuable.
 If you are interested in adding new tidiers methods to broom, please
 read `vignette("adding-tidiers")`.
 
-We have a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By
+We have a [Contributor Code of Conduct](docs/CODE_OF_CONDUCT.md). By
 participating in broom you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ valuable.
 If you are interested in adding new tidiers methods to broom, please
 read `vignette("adding-tidiers")`.
 
-We have a [Contributor Code of Conduct](docs/CODE_OF_CONDUCT.md). By
+We have a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By
 participating in broom you agree to abide by its terms.


### PR DESCRIPTION
The link from `README.md` to the `CODE_OF_CONDUCT.md` was broken, probably because it was moved into `.github`. This should fix it.