### PR TITLE
Patch lavaan glance bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ in the augment method for the chi sq test, .residuals column was renamed to .res
 - `tidy.htest()` column names are now run through `make.names()` to ensure syntactic correctness (#549 by @karissawhiting) 
 - Added method `tidy.lm.beta()` to tidy `lm.beta` class models (#545 by @mattle24)
 - Add feature for glance.biglm to return df.residual
+- Patch bug in glance.lavaan (#577)
 
 
 ## Deprecations

--- a/R/lavaan-tidiers.R
+++ b/R/lavaan-tidiers.R
@@ -125,7 +125,7 @@ glance.lavaan <- function(x, ...) {
           "cfi"
         )
     ) %>%
-    as_tibble() %>%
+    as_tibble(rownames = NA) %>%
     tibble::rownames_to_column(var = "term") %>%
     spread(., term, value) %>%
     bind_cols(


### PR DESCRIPTION
`glance.lavaan()` is returning an error currently. This appears to be because `as_tibble()` is not passing on the names of the lavaan fit measures to the created tibble since tibble 2.0.0 defaults to NULL row names. 

Addressing https://github.com/tidymodels/broom/issues/571