### PR TITLE
Added frailty() handling to tidy.coxph(). Closes #566.

### DIFF
--- a/R/survival-coxph-tidiers.R
+++ b/R/survival-coxph-tidiers.R
@@ -76,13 +76,19 @@ tidy.coxph <- function(x, exponentiate = FALSE, conf.int = FALSE,
   }
   co <- stats::coef(s)
   
-  if (s$used.robust) {
+  if (! is.null(x$frail)){
+    nn <- c("estimate", "std.error", "statistic", "p.value")
+  }else if (s$used.robust) {
     nn <- c("estimate", "std.error", "robust.se", "statistic", "p.value")
   } else {
     nn <- c("estimate", "std.error", "statistic", "p.value")
   }
   
-  ret <- fix_data_frame(co[, -2, drop = FALSE], nn)
+  if (is.null(x$frail)){
+    ret <- fix_data_frame(co[, -2, drop = FALSE], nn)
+  } else{
+    ret <- fix_data_frame(co[, -c(3, 5), drop = FALSE], nn)
+  }
   
   if (exponentiate) {
     ret$estimate <- exp(ret$estimate)

--- a/tests/testthat/test-survival-coxph.R
+++ b/tests/testthat/test-survival-coxph.R
@@ -8,6 +8,7 @@ library(survival)
 
 fit <- coxph(Surv(time, status) ~ age + sex, lung)
 fit2 <- coxph(Surv(time, status) ~ age + sex, lung, robust = TRUE)
+fit3 <- coxph(Surv(time, status) ~ age + sex + frailty(inst), lung)
 
 test_that("coxph tidier arguments", {
   check_arguments(tidy.coxph)
@@ -19,10 +20,14 @@ test_that("tidy.coxph", {
   td <- tidy(fit)
   td2 <- tidy(fit, exponentiate = TRUE)
   td3 <- tidy(fit2)
+  td4 <- tidy(fit3)
+  td5 <- tidy(fit3, exponentiate = TRUE)
   
   check_tidy_output(td)
   check_tidy_output(td2)
   check_tidy_output(td3)
+  check_tidy_output(td4)
+  check_tidy_output(td5)
 })
 
 test_that("glance.coxph", {


### PR DESCRIPTION
This fixes #566 
If frailty() is added, then the summary(fit) does not include $used.robust. This is probably because robust is now deprecated anyway (in favour of cluster). So I've added `! is.null(x$frail)` to avoid the `if (s$used.robust)` which was creating the error - since s$used.robust is NULL for a model with frailty.
For selecting the output, I have called the variables
coef => estimate
se(coef) => std.error
se2 => IGNORE
Chisq => statistic
DF => IGNORE
p.value => p
To ignore columns se2 and DF (columns 3 and 5), I have followed the style of the code currently there, so:
# already there for models without frailty()
`ret <- fix_data_frame(co[, -2, drop = FALSE], nn)`
# my handling of frailty output:
`ret <- fix_data_frame(co[, -c(3, 5), drop = FALSE], nn)`

(Both of these should probably re-written using select(), but following the local style for now.)