### PR TITLE
Add conf.int and conf.level argument to tidy.gam

### DIFF
--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -37,17 +37,26 @@
 #' @aliases mgcv_tidiers gam_tidiers tidy.gam
 #' @family mgcv tidiers
 #' @seealso [tidy()], [mgcv::gam()], [tidy.Gam()]
-tidy.gam <- function(x, parametric = FALSE, ...) {
+tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE, 
+                     conf.level = 0.95, ...) {
   if (parametric) {
     px <- summary(x)$p.table
     px <- as.data.frame(px)
-    fix_data_frame(px, c("estimate", "std.error", "statistic", "p.value"))
+    ret <- fix_data_frame(px, c("estimate", "std.error", "statistic", "p.value"))
   } else {
     sx <- summary(x)$s.table
     sx <- as.data.frame(sx)
     class(sx) <- c("anova", "data.frame")
-    tidy(sx)
+    ret <- tidy(sx)
   }
+  if (conf.int) {
+    # avoid "Waiting for profiling to be done..." message
+    CI <- suppressMessages(stats::confint.default(x, level = conf.level)[rownames(px), ,drop = FALSE])
+    # Think about rank deficiency
+    colnames(CI) <- c("conf.low", "conf.high")
+    ret <- cbind(ret, trans(unrowname(CI)))
+  }
+  ret
 }
 
 #' @templateVar class gam

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -39,18 +39,21 @@
 #' @seealso [tidy()], [mgcv::gam()], [tidy.Gam()]
 tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE, 
                      conf.level = 0.95, ...) {
-  if (parametric) {
+    if (!parametric && conf.int) {
+      message("Confidence intervals only available for parametric terms.")
+    }
+    if (parametric) {
     px <- summary(x)$p.table
     px <- as.data.frame(px)
     ret <- fix_data_frame(px, c("estimate", "std.error", "statistic", "p.value"))
     if (conf.int) {
       # avoid "Waiting for profiling to be done..." message
-      # this doesn't seem to happen with confint.default
+      # This message doesn't seem to happen with confint.default
       CI <- suppressMessages(stats::confint.default(x, level = conf.level)[rownames(px), ,drop = FALSE])
       # Think about rank deficiency
       colnames(CI) <- c("conf.low", "conf.high")
       ret <- cbind(ret, unrowname(CI))
-      ret <- as_tibble(ret)
+    ret <- as_tibble(ret)
     }
   } else {
     sx <- summary(x)$s.table

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -5,6 +5,7 @@
 #' @param parametric Logical indicating if parametric or smooth terms should
 #'   be tidied. Defaults to `FALSE`, meaning that smooth terms are tidied
 #'   by default.
+#' @template param_confint 
 #' @template param_unused_dots
 #' 
 #' @evalRd return_tidy(

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -17,7 +17,7 @@
 #'   "ref.df"
 #' )
 #'
-#' @details When `parametric = TRUE` return columns `edf` and `ref.df` rather
+#' @details When `parametric = FALSE` return columns `edf` and `ref.df` rather
 #'   than `estimate` and `std.error`.
 #' 
 #'   To tidy `Gam` objects created by calls to [gam::gam()],

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -43,18 +43,20 @@ tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE,
     px <- summary(x)$p.table
     px <- as.data.frame(px)
     ret <- fix_data_frame(px, c("estimate", "std.error", "statistic", "p.value"))
+    if (conf.int) {
+      # avoid "Waiting for profiling to be done..." message
+      # this doesn't seem to happen with confint.default
+      CI <- suppressMessages(stats::confint.default(x, level = conf.level)[rownames(px), ,drop = FALSE])
+      # Think about rank deficiency
+      colnames(CI) <- c("conf.low", "conf.high")
+      ret <- cbind(ret, unrowname(CI))
+      ret <- as_tibble(ret)
+    }
   } else {
     sx <- summary(x)$s.table
     sx <- as.data.frame(sx)
     class(sx) <- c("anova", "data.frame")
     ret <- tidy(sx)
-  }
-  if (conf.int) {
-    # avoid "Waiting for profiling to be done..." message
-    CI <- suppressMessages(stats::confint.default(x, level = conf.level)[rownames(px), ,drop = FALSE])
-    # Think about rank deficiency
-    colnames(CI) <- c("conf.low", "conf.high")
-    ret <- cbind(ret, trans(unrowname(CI)))
   }
   ret
 }

--- a/man/mgcv_tidy_gam.Rd
+++ b/man/mgcv_tidy_gam.Rd
@@ -6,7 +6,8 @@
 \alias{gam_tidiers}
 \title{Tidy a(n) gam object}
 \usage{
-\method{tidy}{gam}(x, parametric = FALSE, ...)
+\method{tidy}{gam}(x, parametric = FALSE, conf.int = FALSE,
+  conf.level = 0.95, ...)
 }
 \arguments{
 \item{x}{A \code{gam} object returned from a call to \code{\link[mgcv:gam]{mgcv::gam()}}.}
@@ -14,6 +15,13 @@
 \item{parametric}{Logical indicating if parametric or smooth terms should
 be tidied. Defaults to \code{FALSE}, meaning that smooth terms are tidied
 by default.}
+
+\item{conf.int}{Logical indicating whether or not to include a confidence
+interval in the tidied output. Defaults to \code{FALSE}.}
+
+\item{conf.level}{The confidence level to use for the confidence interval
+if \code{conf.int = TRUE}. Must be strictly greater than 0 and less than 1.
+Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be
@@ -34,7 +42,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \details{
-When \code{parametric = TRUE} return columns \code{edf} and \code{ref.df} rather
+When \code{parametric = FALSE} return columns \code{edf} and \code{ref.df} rather
 than \code{estimate} and \code{std.error}.
 
 To tidy \code{Gam} objects created by calls to \code{\link[gam:gam]{gam::gam()}},


### PR DESCRIPTION
Closes #564.

- Added conf.int and conf.level parameters to tidy.gam() function and to the corresponding documentation.
- Only added confidence interval when parametric = TRUE
- Added message when parametric = FALSE and conf.int = TRUE