### PR TITLE
partial fix for #589

### DIFF
--- a/R/orcutt-tidiers.R
+++ b/R/orcutt-tidiers.R
@@ -30,9 +30,11 @@
 #' @seealso [orcutt::cochrane.orcutt()]
 tidy.orcutt <- function(x, ...) {
   warning("deal with tidy.orcutt conf.int nonsense")
-  tidy.lm(x, ...)
-}
+  dots <- enquos(...)
+  dots$conf.int <- FALSE
 
+  rlang::exec(tidy.lm, x, !!!dots)
+}
 
 #' @templateVar class orcutt
 #' @template title_desc_glance

--- a/R/robust-glmrob-tidiers.R
+++ b/R/robust-glmrob-tidiers.R
@@ -22,7 +22,12 @@
 #' @family robust tidiers
 #' @seealso [robust::glmRob()]
 #' @include stats-lm-tidiers.R
-tidy.glmRob <- tidy.lm
+tidy.glmRob <- function (x, ...) {
+  dots <- enquos(...)
+  dots$conf.int <- FALSE
+
+  rlang::exec(tidy.lm, x, !!!dots)
+}
 
 #' @templateVar class glmRob
 #' @template title_desc_augment

--- a/man-roxygen/param_quick.R
+++ b/man-roxygen/param_quick.R
@@ -1,4 +1,4 @@
-#' @param quick Logical indiciating if the only the `term` and `estimate`
+#' @param quick Logical indicating if the only the `term` and `estimate`
 #'   columns should be returned. Often useful to avoid time consuming
 #'   covariance and standard error calculations. Defaults to `FALSE`.
 #' @md


### PR DESCRIPTION
`glmRob` tidier defaults to `conf.int = FALSE`
This PR doesn't address the issue with `quick` argument (in #589)