### PR TITLE
WIP: Add number of observations to `glance` output.

### DIFF
--- a/R/nnet-tidiers.R
+++ b/R/nnet-tidiers.R
@@ -106,7 +106,8 @@ glance.multinom <- function(x, ...) {
     tibble(
       edf = edf,
       deviance = deviance,
-      AIC = AIC
+      AIC = AIC,
+      n = nrow(x$residuals)
     )
   )
 }

--- a/R/plm-tidiers.R
+++ b/R/plm-tidiers.R
@@ -81,7 +81,8 @@ glance.plm <- function(x, ...) {
     r.squared = r.squared[1],
     adj.r.squared = r.squared[2],
     statistic = fstatistic$statistic,
-    p.value = fstatistic$p.value
+    p.value = fstatistic$p.value,
+    n = length(s$residuals)
   ))
   finish_glance(ret, x)
 }

--- a/R/robust-glmrob-tidiers.R
+++ b/R/robust-glmrob-tidiers.R
@@ -63,7 +63,8 @@ augment.glmRob <- function(x, ...) {
 glance.glmRob <- function(x, ...) {
   ret <- tibble(
     deviance = x$deviance,
-    null.deviance = x$null.deviance
+    null.deviance = x$null.deviance,
+    n = length(x$residuals)
   )
   finish_glance(ret, x)
 }

--- a/R/robust-lmrob-tidiers.R
+++ b/R/robust-lmrob-tidiers.R
@@ -92,6 +92,7 @@ glance.lmRob <- function(x, ...) {
     r.squared = x$r.squared,
     deviance = x$dev,
     sigma = s$sigma,
-    df.residual = x$df.residual
+    df.residual = x$df.residual,
+    n = length(x$residuals)
   )
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -375,6 +375,10 @@ finish_glance <- function(ret, x) {
   }
   ret$df.residual <- tryCatch(df.residual(x), error = function(e) NULL)
   
+  if (!'n' %in% names(ret)) {
+    ret$n <- tryCatch(stats::nobs(x), error = function(e) NULL)
+  }
+  
   as_tibble(ret, rownames = NULL)
 }
 


### PR DESCRIPTION
Where `n` is not specified explicitly in the model-specific `glance` function, `finish_glance` tries to extract the number of observations using `stats::nobs`.

This addresses: https://github.com/tidymodels/broom/issues/82