### PR TITLE
Add pkgdown site url to DESCRIPTION.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -246,7 +246,7 @@ Description: Summarizes key information about statistical
     observations to a dataset, such as fitted values or influence
     measures.
 License: MIT + file LICENSE
-URL: http://github.com/tidymodels/broom
+URL: https://broom.tidyverse.org/, http://github.com/tidymodels/broom
 BugReports: http://github.com/tidymodels/broom/issues
 Depends:
     R (>= 3.1)


### PR DESCRIPTION
Having this url in` DESCRIPTION` will allow autolinking to pkgdown reference pages.

cc @hadley