### PR TITLE
Fix #706 : When grouped by a column with space in its name, tidy() throws error on 0.5.2

### DIFF
--- a/R/dplyr-rowwise-df-tidiers.R
+++ b/R/dplyr-rowwise-df-tidiers.R
@@ -9,7 +9,7 @@ apply_rowwise_df <- function(x, object, func, data, ...) {
   groupers <- colnames(x)[sapply(x, function(e) class(e)[1]) != "list"]
   groupers <- setdiff(groupers, object)
   # suppress "group_by" warning
-  x <- suppressWarnings(group_by_(x, .dots = as.list(groupers)))
+  x <- suppressWarnings(group_by(x, !!!rlang::syms(groupers)))
   # let the "data" argument specify column (for augment)
   if (!missing(data)) {
     if (as.character(substitute(data)) %in% colnames(x)) {


### PR DESCRIPTION
Used !!!syms() to pass group columns to group_by in dplyr-rowwise-df-tidiers.R to fix #706.

Verified the fix with the replex

```
> mtcars %>% rename(`a m`=am) %>% group_by(`a m`) %>% do(model = lm(mpg ~ .,data=.)) %>% tidy(model)
# A tibble: 20 x 6
# Groups:   a m [2]
   `a m` term         estimate std.error statistic p.value
   <dbl> <chr>           <dbl>     <dbl>     <dbl>   <dbl>
 1     0 (Intercept)    8.64     21.5        0.402  0.697 
 2     0 cyl           -0.534     1.13      -0.474  0.647 
 3     0 disp          -0.0203    0.0174    -1.16   0.275 
 4     0 hp             0.0622    0.0461     1.35   0.210 
 5     0 drat           0.592     3.01       0.196  0.849 
 6     0 wt             1.95      2.23       0.876  0.404 
 7     0 qsec          -0.884     0.758     -1.17   0.274 
 8     0 vs             0.739     2.51       0.294  0.775 
 9     0 gear           8.65      3.90       2.22   0.0534
10     0 carb          -4.81      1.90      -2.53   0.0322
11     1 (Intercept) -138.       69.1       -1.99   0.140 
12     1 cyl           -1.28      4.54      -0.282  0.796 
13     1 disp           0.180     0.176      1.02   0.381 
14     1 hp            -0.160     0.143     -1.12   0.345 
15     1 drat          -4.95      5.47      -0.905  0.432 
16     1 wt           -10.5       5.00      -2.11   0.125 
17     1 qsec           8.09      3.45       2.35   0.101 
18     1 vs             0.943     5.09       0.185  0.865 
19     1 gear          12.3       6.66       1.85   0.161 
20     1 carb           4.69      4.06       1.15   0.332 
```