### PR TITLE
Replaces parameter with term for tidy.epi.2byb2() as per #718

### DIFF
--- a/R/epiR-tidiers.R
+++ b/R/epiR-tidiers.R
@@ -35,13 +35,13 @@ tidy.epi.2by2 <- function(x, parameters = c("moa", "stat"),...) {
       tidyr::unnest() %>% 
       dplyr::filter(!is.na(.$est)) %>% 
       dplyr::select(keep) %>% 
-      dplyr::rename_all(funs(c("parameter", "estimate", "conf.low", "conf.high")))
+      dplyr::rename_all(funs(c("term", "estimate", "conf.low", "conf.high")))
   } else if (method == "stat") {
     keep <- c("measure", "test.statistic", "df", "p.value")
     tibble::tibble(s, measure = nm) %>% 
       tidyr::unnest() %>% 
       dplyr::filter(!is.na(.$test.statistic)) %>% 
       dplyr::select(keep) %>% 
-      dplyr::rename_all(funs(c("parameter", "statistic", "df", "p.value")))
+      dplyr::rename_all(funs(c("term", "statistic", "df", "p.value")))
   }
 }

--- a/R/epiR-tidiers.R
+++ b/R/epiR-tidiers.R
@@ -6,7 +6,7 @@
 #'    default is `moa` (measures of association)
 #' @template param_unused_dots
 #'
-#' @evalRd return_tidy("parameter", estimate = "Estimated measure of association", "conf.low", "conf.high", "statistic", "df", "p.value")
+#' @evalRd return_tidy("term", estimate = "Estimated measure of association", "conf.low", "conf.high", "statistic", "df", "p.value")
 #' 
 #' @details The tibble has a column for each of the measures of association or tests contained in `massoc` when 
 #'    [epiR::epi.2by2()] is called. 


### PR DESCRIPTION
Tiny change! Rerunning the snippet from #715 

```
library(broom)
library(epiR)
#> Loading required package: survival
#> Package epiR 1.0-2 is loaded
#> Type help(epi.about) for summary information
#> 

dat <- matrix(c(13,2163,5,3349), nrow = 2, byrow = TRUE)
rownames(dat) <- c("DF+", "DF-")
colnames(dat) <- c("FUS+", "FUS-")
fit <- epi.2by2(dat = as.table(dat), method = "cross.sectional", 
                conf.level = 0.95, units = 100, outcome = "as.columns")
```

Now returns:

```
# A tibble: 12 x 4
   term                estimate conf.low conf.high
   <chr>                  <dbl>    <dbl>     <dbl>
 1 PR.strata.wald         4.01    1.43      11.2  
 2 PR.strata.score        4.01    1.49      10.8  
 3 OR.strata.wald         4.03    1.43      11.3  
 4 OR.strata.score        4.03    1.49      10.9  
 5 OR.strata.cfield       4.03    1.47      12.6  
 6 OR.strata.mle          4.02    1.34      14.4  
 7 ARisk.strata.wald      0.448   0.0992     0.797
 8 ARisk.strata.score     0.448   0.142      0.882
 9 PARisk.strata.wald     0.176  -0.0225     0.375
10 PARisk.strata.piri     0.176   0.0389     0.314
11 AFRisk.strata.wald     0.750   0.301      0.911
12 PAFRisk.strata.wald    0.542   0.0361     0.782
```


NOTE: While this passes the model-specific test in devtools::test(), it outputs the following warning:

```
test-epiR.R:33: warning: tidy.epi2by2
funs() is soft deprecated as of dplyr 0.8.0
Please use a list of either functions or lambdas: 

  # Simple named list: 
  list(mean = mean, median = median)

  # Auto named with `tibble::lst()`: 
  tibble::lst(mean, median)

  # Using lambdas
  list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))
```

Should I change funs() here as well, and if so is there a preferred style between list/tibble::list/list with lambas? Thank you!