### PR TITLE
Rma tidiers

### DIFF
--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -6,7 +6,7 @@
 #'   [metafor::rma.mv()], or [metafor::rma.peto()].
 #' @inheritParams tidy.lm
 #' @param include_studies Logical. Should individual studies be included in the
-#'    output? Defaults to `TRUE`.
+#'    output? Defaults to `FALSE`.
 #' @template param_unused_dots
 #' @param measure Measure type. See [metafor::escalc()]
 #'
@@ -43,7 +43,7 @@
 #' @rdname metafor_tidiers
 #' 
 tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95, exponentiate = FALSE,
-                     include_studies = TRUE, measure = "GEN", ...) {
+                     include_studies = FALSE, measure = "GEN", ...) {
   # tidy summary estimates
   betas <- x$beta
   if (!is.null(nrow(betas)) && nrow(betas) > 1) {

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -11,7 +11,7 @@
 #' @param measure Measure type. See [metafor::escalc()]
 #'
 #' @evalRd return_tidy(
-#'   study = "The name of the individual study",
+#'   term = "The name of the individual study",
 #'   type = "The estimate type  (summary vs individual study)",
 #'   "estimate",
 #'   "std.error",
@@ -119,7 +119,8 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95, exponentiate = FALS
 #'   "cochran.qe", 
 #'   "p.value.cochran.qe", 
 #'   "cochran.qm", 
-#'   "p.value.cochran.qm"
+#'   "p.value.cochran.qm",
+#'   "df.residual"
 #' )
 #' @export
 #'

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -165,6 +165,7 @@ glance.rma <- function(x, ...) {
     df.residual = df.residual(x)
   ) %>%
     purrr::discard(is.null) %>%
+    purrr::discard(purrr::is_empty) %>%
     # drop multivariate statistics
     purrr::discard(~length(.x) >= 2) %>%
     as_tibble()

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -161,7 +161,8 @@ glance.rma <- function(x, ...) {
     cochran.qe = x$QE,
     p.value.cochran.qe = x$QEp,
     cochran.qm = x$QM,
-    p.value.cochran.qm = x$QMp
+    p.value.cochran.qm = x$QMp,
+    df.residual = df.residual(x)
   ) %>%
     purrr::discard(is.null) %>%
     # drop multivariate statistics

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -58,7 +58,7 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95, exponentiate = FALS
   }
   
   results <- tibble::tibble(
-    study = study, 
+    term = study, 
     type = "summary",
     estimate = betas, 
     std.error = x$se,
@@ -78,7 +78,7 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95, exponentiate = FALS
     n_studies <- length(x$slab)
     
     estimates <- dplyr::bind_cols(
-      study = as.character(x$slab), 
+      term = as.character(x$slab), 
       # dplyr::bind_cols is strict about recycling, so repeat for each study
       type = rep("study", n_studies), 
       estimates[, c("yi", "sei", "zi")], 
@@ -86,7 +86,7 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95, exponentiate = FALS
       estimates[, c("ci.lb", "ci.ub")] 
     )
     
-    names(estimates) <- c("study", "type", "estimate", "std.error", "statistic",
+    names(estimates) <- c("term", "type", "estimate", "std.error", "statistic",
                           "p.value", "conf.low", "conf.high")
     estimates <- as_tibble(estimates)
     results <- dplyr::bind_rows(estimates, results) 

--- a/man/glance.rma.Rd
+++ b/man/glance.rma.Rd
@@ -59,6 +59,7 @@ glance(meta_analysis)
 A \code{\link[tibble:tibble]{tibble::tibble()}} with exactly one row and columns:
   \item{cochran.qe}{In meta-analysis, test statistic for the Cochran's Q_e test of residual heterogeneity.}
   \item{cochran.qm}{In meta-analysis, test statistic for the Cochran's Q_m omnibus test of coefficients.}
+  \item{df.residual}{Residual degrees of freedom.}
   \item{h.squared}{Value of the H-Squared statistic}
   \item{i.squared}{Value of the I-Squared statistic}
   \item{measure}{the measure used in the meta-analysis}

--- a/man/metafor_tidiers.Rd
+++ b/man/metafor_tidiers.Rd
@@ -5,7 +5,8 @@
 \title{Tidy a(n) rma object}
 \usage{
 \method{tidy}{rma}(x, conf.int = FALSE, conf.level = 0.95,
-  exponentiate = FALSE, include_studies = TRUE, measure = "GEN", ...)
+  exponentiate = FALSE, include_studies = FALSE, measure = "GEN",
+  ...)
 }
 \arguments{
 \item{x}{An \code{rma} object such as those created by \code{\link[metafor:rma]{metafor::rma()}},
@@ -25,7 +26,7 @@ regressions, but a bad idea if there is no log or logit link. Defaults
 to \code{FALSE}.}
 
 \item{include_studies}{Logical. Should individual studies be included in the
-output? Defaults to \code{TRUE}.}
+output? Defaults to \code{FALSE}.}
 
 \item{measure}{Measure type. See \code{\link[metafor:escalc]{metafor::escalc()}}}
 

--- a/man/metafor_tidiers.Rd
+++ b/man/metafor_tidiers.Rd
@@ -75,7 +75,7 @@ A \code{\link[tibble:tibble]{tibble::tibble()}} with columns:
   \item{p.value}{The two-sided p-value associated with the observed statistic.}
   \item{statistic}{The value of a T-statistic to use in a hypothesis that the regression term is non-zero.}
   \item{std.error}{The standard error of the regression term.}
-  \item{study}{The name of the individual study}
+  \item{term}{The name of the individual study}
   \item{type}{The estimate type  (summary vs individual study)}
 
 }


### PR DESCRIPTION
This PR sets up the tidiers for the metafor package to work with the mice package, as discussed in #689 (cc: @wviechtb ). The changes made to do this were:

* set `include_studies` to `FALSE` by default
* change `study` to `term`
* add `residual.df` to `glance.rma()`

Closes #689.

I didn't add mice to suggests to formally test this, but here is the example from @wviechtb:

``` r
library(broom)
library(metafor)
library(mice)

dat <- data.frame(yi = c(.1, .2, .3, .4, .5), 
                  vi = c(.01, .02, .04, .02, .01), 
                  xi = c(0, 2, 1, NA, 5))
imp <- mice(dat, print=FALSE, seed=1234)

fit <- with(imp, rma(yi, vi, mods = ~ xi))
pool <- pool(fit)


pool <- pool(fit)
round(summary(pool), 4)
#>           estimate std.error statistic     df p.value
#> intercept   0.1414    0.0847    1.6690 1.8383  0.2478
#> xi          0.0710    0.0269    2.6366 1.9668  0.1208
```

<sup>Created on 2019-10-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>