### PR TITLE
lfe-tidier: add argument robust to tidy #772

### DIFF
--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -5,6 +5,8 @@
 #' @template param_confint
 #' @param fe Logical indicating whether or not to include estimates of
 #'   fixed effects. Defaults to `FALSE`.
+#' @param robust Logical indicating robust or clustered SEs should be used.
+#'   See lfe::summary.felm for details. Defaults to `FALSE`.
 #' @template param_unused_dots
 #'
 #' @evalRd return_tidy(regression = TRUE)
@@ -28,9 +30,10 @@
 #' 
 #' result_felm <- felm(v2~v3|id+v1, DT)
 #' tidy(result_felm, fe = TRUE)
+#' tidy(result_felm, robust = TRUE)
 #' augment(result_felm)
 #' 
-#' v1<-DT$v1
+#' v1 <- DT$v1
 #' v2 <- DT$v2
 #' v3 <- DT$v3
 #' id <- DT$id
@@ -44,7 +47,7 @@
 #' @aliases felm_tidiers lfe_tidiers
 #' @family felm tidiers
 #' @seealso [tidy()], [lfe::felm()]
-tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, ...) {
+tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, robust = FALSE, ...) {
 
   has_multi_response <- length(x$lhs) > 1
   
@@ -56,7 +59,7 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, ...) {
       select(response, everything())
     
   } else {
-    ret <- fix_data_frame(stats::coef(summary(x)), nn)  
+    ret <- fix_data_frame(stats::coef(summary(x, robust = robust)), nn)  
   }
   
 

--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -53,7 +53,7 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, robust 
   
   nn <- c("estimate", "std.error", "statistic", "p.value")
   if(has_multi_response) {
-    ret <-  map_df(x$lhs, function(y) stats::coef(summary(x, lhs = y)) %>% 
+    ret <-  map_df(x$lhs, function(y) stats::coef(summary(x, lhs = y, robust = robust)) %>% 
                      fix_data_frame(nn) %>% 
                      mutate(response = y)) %>% 
       select(response, everything())

--- a/man/augment.felm.Rd
+++ b/man/augment.felm.Rd
@@ -85,9 +85,10 @@ augment(result_felm)
 
 result_felm <- felm(v2~v3|id+v1, DT)
 tidy(result_felm, fe = TRUE)
+tidy(result_felm, robust = TRUE)
 augment(result_felm)
 
-v1<-DT$v1
+v1 <- DT$v1
 v2 <- DT$v2
 v3 <- DT$v3
 id <- DT$id

--- a/man/glance.felm.Rd
+++ b/man/glance.felm.Rd
@@ -53,9 +53,10 @@ augment(result_felm)
 
 result_felm <- felm(v2~v3|id+v1, DT)
 tidy(result_felm, fe = TRUE)
+tidy(result_felm, robust = TRUE)
 augment(result_felm)
 
-v1<-DT$v1
+v1 <- DT$v1
 v2 <- DT$v2
 v3 <- DT$v3
 id <- DT$id

--- a/man/tidy.felm.Rd
+++ b/man/tidy.felm.Rd
@@ -7,7 +7,7 @@
 \title{Tidy a(n) felm object}
 \usage{
 \method{tidy}{felm}(x, conf.int = FALSE, conf.level = 0.95,
-  fe = FALSE, ...)
+  fe = FALSE, robust = FALSE, ...)
 }
 \arguments{
 \item{x}{A \code{felm} object returned from \code{\link[lfe:felm]{lfe::felm()}}.}
@@ -21,6 +21,9 @@ Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
 
 \item{fe}{Logical indicating whether or not to include estimates of
 fixed effects. Defaults to \code{FALSE}.}
+
+\item{robust}{Logical indicating robust or clustered SEs should be used.
+See lfe::summary.felm for details. Defaults to \code{FALSE}.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be
@@ -59,9 +62,10 @@ augment(result_felm)
 
 result_felm <- felm(v2~v3|id+v1, DT)
 tidy(result_felm, fe = TRUE)
+tidy(result_felm, robust = TRUE)
 augment(result_felm)
 
-v1<-DT$v1
+v1 <- DT$v1
 v2 <- DT$v2
 v3 <- DT$v3
 id <- DT$id

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -30,22 +30,32 @@ test_that("felm tidier arguments", {
 })
 
 test_that("tidy.felm", {
-  td <- tidy(fit)
+  td1 <- tidy(fit)
   td2 <- tidy(fit2, conf.int = TRUE, fe = TRUE, fe.error = FALSE)
   td3 <- tidy(fit2, conf.int = TRUE, fe = TRUE)
   td4 <- tidy(fit_form)
+  td5 <- tidy(fit, robust = TRUE)
+  td6 <- tidy(fit2, robust = TRUE)
+  td7 <- tidy(fit2, robust = TRUE, fe = TRUE)
   
   td_multi <- tidy(fit_multi)
 
-  check_tidy_output(td)
+  check_tidy_output(td1)
   check_tidy_output(td2)
   check_tidy_output(td3)
   check_tidy_output(td4)
+  check_tidy_output(td5)
+  check_tidy_output(td6)
+  check_tidy_output(td7)
   check_tidy_output(td_multi)
 
-  check_dims(td, 2, 5)
+  check_dims(td1, 2, 5)
   
   expect_equal(tidy(fit_multi)[3:4, -1], tidy(fit))
+  expect_equal(dplyr::pull(td5, std.error), 
+               as.numeric(lfe:::summary.felm(fit, robust = TRUE)$coef[, "Robust s.e"]))
+  expect_equal(dplyr::pull(td6, std.error), 
+               as.numeric(lfe:::summary.felm(fit2, robust = TRUE)$coef[, "Robust s.e"]))
 })
 
 test_that("glance.felm", {


### PR DESCRIPTION
This is the proposed fix to #772. This fix allows the reporting of correct standard errors being reported out, instead of silently giving wrong ones.