### PR TITLE
Corrected sign on `.resid`

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -343,7 +343,7 @@ augment_newdata <- function(x, data, newdata, .se_fit, ...) {
   
   resp <- safe_response(x, df)
   if (!is.null(resp) && is.numeric(resp))
-    df$.resid <- df$.fitted - resp
+    df$.resid <- resp - df$.fitted
   df
 }
 


### PR DESCRIPTION
According to #778, the sign for residual calculation is flipped. I applied the change and made this PR. 