### PR TITLE
nest(data = -keep_col)

### DIFF
--- a/vignettes/broom_and_dplyr.Rmd
+++ b/vignettes/broom_and_dplyr.Rmd
@@ -71,7 +71,7 @@ library(tidyr)
 library(purrr)
 
 nested <- Orange %>% 
-  nest(-Tree)
+  nest(data = -Tree)
 ```
 
 Then we run a correlation test for each nested tibble using `purrr::map`:
@@ -95,7 +95,7 @@ Finally, we want to unnest the tidied data frames so we can see the results in a
 
 ```{r}
 Orange %>% 
-  nest(-Tree) %>% 
+  nest(data = -Tree) %>% 
   mutate(
     test = map(data, ~ cor.test(.x$age, .x$circumference)), # S3 list-col
     tidied = map(test, tidy)
@@ -122,7 +122,7 @@ Now we can handle multiple regressions at once using exactly the same workflow a
 
 ```{r}
 Orange %>%
-  nest(-Tree) %>% 
+  nest(data = -Tree) %>% 
   mutate(
     fit = map(data, ~ lm(age ~ circumference, data = .x)),
     tidied = map(fit, tidy)
@@ -138,7 +138,7 @@ mtcars <- as_tibble(mtcars)  # to play nicely with list-cols
 mtcars
 
 mtcars %>%
-  nest(-am) %>% 
+  nest(data = -am) %>% 
   mutate(
     fit = map(data, ~ lm(wt ~ mpg + qsec + gear, data = .x)),  # S3 list-col
     tidied = map(fit, tidy)
@@ -150,7 +150,7 @@ What if you want not just the `tidy` output, but the `augment` and `glance` outp
 
 ```{r}
 regressions <- mtcars %>%
-  nest(-am) %>% 
+  nest(data = -am) %>% 
   mutate(
     fit = map(data, ~ lm(wt ~ mpg + qsec + gear, data = .x)),
     tidied = map(fit, tidy),


### PR DESCRIPTION
Argument `data` in function [nest()](https://tidyr.tidyverse.org/reference/nest.html) {tidyr} v1.0.0 should be explicit. Otherwise, there is a warning.

``` r
library(tidyr)
library(magrittr)
#> 
#> Attaching package: 'magrittr'
#> The following object is masked from 'package:tidyr':
#> 
#>     extract
nested <- Orange %>% 
  nest(-Tree)
#> Warning: All elements of `...` must be named.
#> Did you want `data = c(age, circumference)`?
```

<sup>Created on 2019-12-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
