### PR TITLE
new tidiers: mice for pooled imputed models

### DIFF
--- a/R/mice-tidiers.R
+++ b/R/mice-tidiers.R
@@ -1,0 +1,125 @@
+#' @templateVar class mipo
+#' @template title_desc_tidy
+#' 
+#' @param x A `mipo` objected returned by [mice::pool()].
+#' @template param_confint
+#' @template param_unused_dots
+#' @evalRd return_tidy(
+#'     "estimate",
+#'     "ubar",
+#'     "b",
+#'     "t",
+#'     "dfcom",
+#'     "df",
+#'     "riv",
+#'     "lambda",
+#'     "fmi",
+#'     "p.value",
+#'     "conf.low", 
+#'     "conf.high")
+#' @aliases mice_tidiers
+#' @export
+#' @seealso [tidy()]
+#' @family mice tidiers
+#'
+#' @examples
+#'
+#' library(mice)
+#' dat <- data.frame(y = c(.1, .2, .3, .4, .5), 
+#'                   x = c(.01, .02, .04, .02, .01), 
+#'                   z = c(0, 2, 1, NA, 5))
+#' imp <- mice(dat, print = FALSE, seed = 1234)
+#' fit <- with(imp, lm(y ~ x + z))
+#' poo <- pool(fit)
+#' tidy(poo, conf.int = TRUE, conf.level = .90)
+#'
+#' glance(poo)
+#'
+#'
+#' return_tidy
+#' @note
+tidy.mipo <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
+
+	# summarize pooled models using summary method supplied by mice
+    # NOTE: could use type = 'all' to extract more information
+	out <- summary(x, conf.int = conf.int, 
+                   conf.level = conf.level, ...)
+
+    # term: factor -> character
+	out$term <- as.character(out$term)
+
+	# rename confidence intervals if present
+	idx <- grepl('^\\d.*\\%', names(out))
+	names(out)[idx] <- c("conf.low", "conf.high")
+
+	# output a tibble
+	out <- tibble::as_tibble(out)
+	out
+}
+
+
+#' @templateVar class mice
+#' @template title_desc_tidy
+#' 
+#' @export
+#' @seealso [tidy()]
+#' @family mice tidiers
+#' @inherit tidy.mipo params examples
+#'
+tidy.mira <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
+	# pool observations
+	out <- mice::pool(x, ...)
+
+    # summarize mipo object
+    out <- tidy(out, conf.int = conf.int, conf.level = conf.level, ...)
+    out
+}
+
+
+#' @templateVar class mice
+#' @template title_desc_glance
+#' 
+#' @inherit tidy.mipo examples
+#'
+#' @evalRd return_glance("nimp")
+#' @export
+#' @seealso [glance()]
+#' @family mice tidiers
+#' @export
+#' @family tidiers
+glance.mipo <- function(x, ...) {
+	out <- tibble::tibble(nimp = x$m[1])
+	out
+}
+
+
+#' @templateVar class mice
+#' @template title_desc_glance
+#' 
+#' @inherit glance.mipo params
+#' @inherit tidy.mipo examples
+#'
+#' @evalRd return_glance(
+#'     "m", 
+#'     "r.squared", 
+#'     "adj.r.squared"
+#'     )
+#' @export
+#' @seealso [glance()]
+#' @family mice tidiers
+#' @export
+glance.mira <- function(x, ...) {
+	poo <- mice::pool(x, ...)
+	out <- glance(poo, ...)
+
+    # number of observations
+	out$nobs <- tryCatch(stats::nobs(x$analyses[[1]]), error = function(e) NULL)
+
+    # if linear model, get r2
+	if (class(x$analyses[[1]])[1] == 'lm') {
+    	out$r.squared <- mice::pool.r.squared(x, adjusted = FALSE)[1]
+	}
+
+	# output
+	out
+}

--- a/tests/testthat/test-mice.R
+++ b/tests/testthat/test-mice.R
@@ -1,0 +1,45 @@
+context("mice tidiers")
+
+skip_if_not_installed("modeltests")
+library(modeltests)
+
+skip_if_not_installed("mice")
+library(mice)
+
+dat <- data.frame(y = c(.1, .2, .3, .4, .5), 
+                  x = c(.01, .02, .04, .02, .01), 
+                  z = c(0, 2, 1, NA, 5))
+imp <- mice(dat, print = FALSE, seed = 1234)
+fit <- with(imp, lm(y ~ x + z))
+poo <- pool(fit)
+
+test_that("mice tidier arguments", {
+  check_arguments(tidy.mira)
+  check_arguments(glance.mira)
+  check_arguments(tidy.mipo)
+  check_arguments(glance.mipo)
+})
+
+test_that("tidy.mipo", {
+  td <- tidy(poo, conf.int = TRUE, conf.level = .99)
+  check_tidy_output(td)
+  check_dims(td, expected_cols = 8)
+})
+
+test_that("glance.mipo", {
+  gl <- glance(poo)
+  check_glance_outputs(gl)
+  check_dims(gl, expected_cols = 1)
+})
+
+test_that("tidy.mira", {
+  td <- tidy(fit, conf.int = TRUE, conf.level = .99)
+  check_tidy_output(td)
+  check_dims(td, expected_cols = 8)
+})
+
+test_that("glance.mira", {
+  gl <- glance(fit)
+  check_glance_outputs(gl)
+  check_dims(gl, expected_cols = 4)
+})


### PR DESCRIPTION
The `mice` package provides functions to deal with missing data using multiple imputation. When users fit models to mice-imputed datasets, they obtain `mipo` or `mira` objects. These tidiers extract information from those object classes.

The `nimp` column in `glance.mira` and `glance.mipo` breaks the test because it is not include in the glossary. This column records the number of imputed datasets.

``` r
library(broom)
library(mice)

# data with missing observations
dat <- data.frame(y = c(.1, .2, .3, .4, .5), 
                  x = c(.01, .02, .04, .02, .01), 
                  z = c(0, 2, 1, NA, 5))

# multiple imputation x5
imp <- mice(dat, print = FALSE, m = 5)

# fit models to the 5 datasets
fit <- with(imp, lm(y ~ x + z))

# pool results
poo <- pool(fit)

# broom
tidy(fit)
#> # A tibble: 3 x 6
#>   term        estimate std.error statistic    df p.value
#>   <chr>          <dbl>     <dbl>     <dbl> <dbl>   <dbl>
#> 1 (Intercept)   0.0921    0.157      0.587  1.07   0.657
#> 2 x             3.45      5.34       0.645  1.18   0.621
#> 3 z             0.0689    0.0352     1.96   1.03   0.295

glance(fit)
#> # A tibble: 1 x 3
#>    nimp  nobs r.squared
#>   <int> <int>     <dbl>
#> 1     5     5     0.726

tidy(poo, conf.int = TRUE, conf.level = .99)
#> # A tibble: 3 x 8
#>   term        estimate std.error statistic    df p.value conf.low conf.high
#>   <chr>          <dbl>     <dbl>     <dbl> <dbl>   <dbl>    <dbl>     <dbl>
#> 1 (Intercept)   0.0921    0.157      0.587  1.07   0.657    -7.75      7.93
#> 2 x             3.45      5.34       0.645  1.18   0.621  -183.      190.  
#> 3 z             0.0689    0.0352     1.96   1.03   0.295    -1.95      2.09

glance(poo)
#> # A tibble: 1 x 1
#>    nimp
#>   <int>
#> 1     5
```

<sup>Created on 2020-04-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>