### PR TITLE
Remove `Naive SE` in tidy.survreg

### DIFF
--- a/R/survival-survreg-tidiers.R
+++ b/R/survival-survreg-tidiers.R
@@ -4,13 +4,13 @@
 #' @param x An `survreg` object returned from [survival::survreg()].
 #' @template param_confint
 #' @template param_unused_dots
-#' 
+#'
 #' @evalRd return_tidy(regression = TRUE)
 #'
 #' @examples
 #'
 #' library(survival)
-#' 
+#'
 #' sr <- survreg(
 #'   Surv(futime, fustat) ~ ecog.ps + rx,
 #'   ovarian,
@@ -24,7 +24,7 @@
 #' # coefficient plot
 #' td <- tidy(sr, conf.int = TRUE)
 #' library(ggplot2)
-#' ggplot(td, aes(estimate, term)) + 
+#' ggplot(td, aes(estimate, term)) +
 #'   geom_point() +
 #'   geom_errorbarh(aes(xmin = conf.low, xmax = conf.high), height = 0) +
 #'   geom_vline(xintercept = 0)
@@ -34,12 +34,15 @@
 #' @seealso [tidy()], [survival::survreg()]
 #' @family survreg tidiers
 #' @family survival tidiers
-#' 
+#'
 tidy.survreg <- function(x, conf.level = .95, conf.int = FALSE, ...) {
-  s <- summary(x)
+  s <- summary(x)$table
+  # If the user requested robust SE in the survreg call, don't return naive SE
+  # (The column is not present if robust=FALSE)
+  s <- s[, colnames(s) != "(Naive SE)", drop = FALSE]
   nn <- c("estimate", "std.error", "statistic", "p.value")
-  ret <- fix_data_frame(s$table, newnames = nn)
-  
+  ret <- fix_data_frame(s, newnames = nn)
+
   if(conf.int){
     # add confidence interval
     ci <- stats::confint(x, level = conf.level)
@@ -47,14 +50,14 @@ tidy.survreg <- function(x, conf.level = .95, conf.int = FALSE, ...) {
     ci <- fix_data_frame(ci)
     ret <- as_tibble(merge(ret, ci, all.x = TRUE, sort = FALSE))
   }
-  
+
   ret
 }
 
 
 #' @templateVar class survreg
 #' @template title_desc_augment
-#' 
+#'
 #' @inherit tidy.survreg params examples
 #' @template param_data
 #' @template param_newdata
@@ -74,7 +77,7 @@ augment.survreg <- function(x, data = NULL, newdata = NULL,
   if (is.null(data) && is.null(newdata)) {
     stop("Must specify either `data` or `newdata` argument.", call. = FALSE)
   }
-  
+
   augment_columns(x, data, newdata,
                   type.predict = type.predict,
                   type.residuals = type.residuals
@@ -84,9 +87,9 @@ augment.survreg <- function(x, data = NULL, newdata = NULL,
 
 #' @templateVar class survreg
 #' @template title_desc_glance
-#' 
+#'
 #' @inherit tidy.survreg params examples
-#' 
+#'
 #' @evalRd return_glance(
 #'   "iter",
 #'   "df",
@@ -98,7 +101,7 @@ augment.survreg <- function(x, data = NULL, newdata = NULL,
 #'   statistic = "Chi-squared statistic.",
 #'   "nobs"
 #' )
-#' 
+#'
 #' @export
 #' @seealso [glance()], [survival::survreg()]
 #' @family survreg tidiers

--- a/tests/testthat/test-survival-survreg.R
+++ b/tests/testthat/test-survival-survreg.R
@@ -19,16 +19,16 @@ test_that("survreg tidier arguments", {
 test_that("tidy.survreg", {
   td <- tidy(sr)
   td2 <- tidy(sr, conf.int = TRUE)
-  
+
   check_tidy_output(td)
   check_tidy_output(td2)
-  
+
   check_dims(td, 3, 5)
   check_dims(td2, 3, 7)
-  
+
   expect_equal(td$term, c("(Intercept)", "ecog.ps", "rx"))
   expect_equal(td2$term, c("(Intercept)", "ecog.ps", "rx"))
-  
+
 })
 
 test_that("glance.survreg", {
@@ -37,16 +37,30 @@ test_that("glance.survreg", {
 })
 
 test_that("augment.survreg", {
-  
+
   expect_error(
     augment(sr),
     regexp = "Must specify either `data` or `newdata` argument."
   )
-  
+
   check_augment_function(
     aug = augment.survreg,
     model = sr,
     data = ovarian,
     newdata = ovarian
   )
+})
+
+test_that("tidy.survreg with robust std err", {
+  sr <- survreg(Surv(futime, fustat) ~ ecog.ps + rx, ovarian,
+                dist = "exponential", robust=TRUE
+  )
+  td <- tidy(sr)
+  td2 <- tidy(sr, conf.int = TRUE)
+
+  check_tidy_output(td)
+  check_tidy_output(td2)
+
+  check_dims(td, 3, 5)
+  check_dims(td2, 3, 7)
 })


### PR DESCRIPTION
I added code to drop the `(Naive SE)` column when `survreg` is run with `robust=TRUE`. This extra column was causing the issues in #728. It would be possible to include it, but that seems less tidy.

I'm having trouble running  the full set of tests, but the survival tests seem fine.

Obviously there are bigger things going on right now. This PR isn't urgent.



Fixes #728 