### PR TITLE
Make augment.felm columns vector, not matrix

### DIFF
--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -10,11 +10,11 @@
 #' @template param_unused_dots
 #'
 #' @evalRd return_tidy(regression = TRUE)
-#'   
+#'
 #' @examples
-#' 
+#'
 #' library(lfe)
-#' 
+#'
 #' N=1e2
 #' DT <- data.frame(
 #'   id = sample(5, N, TRUE),
@@ -27,18 +27,18 @@
 #' result_felm <- felm(v2~v3, DT)
 #' tidy(result_felm)
 #' augment(result_felm)
-#' 
+#'
 #' result_felm <- felm(v2~v3|id+v1, DT)
 #' tidy(result_felm, fe = TRUE)
 #' tidy(result_felm, robust = TRUE)
 #' augment(result_felm)
-#' 
+#'
 #' v1 <- DT$v1
 #' v2 <- DT$v2
 #' v3 <- DT$v3
 #' id <- DT$id
 #' result_felm <- felm(v2~v3|id+v1)
-#' 
+#'
 #' tidy(result_felm)
 #' augment(result_felm)
 #' glance(result_felm)
@@ -50,18 +50,18 @@
 tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, robust = FALSE, ...) {
 
   has_multi_response <- length(x$lhs) > 1
-  
+
   nn <- c("estimate", "std.error", "statistic", "p.value")
   if(has_multi_response) {
-    ret <-  map_df(x$lhs, function(y) stats::coef(summary(x, lhs = y, robust = robust)) %>% 
-                     fix_data_frame(nn) %>% 
-                     mutate(response = y)) %>% 
+    ret <-  map_df(x$lhs, function(y) stats::coef(summary(x, lhs = y, robust = robust)) %>%
+                     fix_data_frame(nn) %>%
+                     mutate(response = y)) %>%
       select(response, everything())
-    
+
   } else {
-    ret <- fix_data_frame(stats::coef(summary(x, robust = robust)), nn)  
+    ret <- fix_data_frame(stats::coef(summary(x, robust = robust)), nn)
   }
-  
+
 
   if (conf.int) {
     # avoid "Waiting for profiling to be done..." message
@@ -72,32 +72,32 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, robust 
 
   if (fe) {
     ret <- mutate(ret, N = NA, comp = NA)
-    
+
     nn <- c("estimate", "std.error", "N", "comp")
-    ret_fe_prep <- lfe::getfe(x, se = TRUE, bN = 100) %>% 
-      tibble::rownames_to_column(var = "term") %>% 
+    ret_fe_prep <- lfe::getfe(x, se = TRUE, bN = 100) %>%
+      tibble::rownames_to_column(var = "term") %>%
       select(term, contains("effect"),  contains("se"), obs, comp) %>% # effect and se are multiple if multiple y
-      rename(N=obs) 
-    
+      rename(N=obs)
+
     if(has_multi_response) {
-      ret_fe_prep <-  ret_fe_prep  %>% 
-        tidyr::gather(key = "stat_resp", value, starts_with("effect."), starts_with("se.")) %>% 
-        tidyr::separate(col = "stat_resp", c("stat", "response"), sep="\\.") %>% 
-        tidyr::spread(key = "stat", value) 
+      ret_fe_prep <-  ret_fe_prep  %>%
+        tidyr::gather(key = "stat_resp", value, starts_with("effect."), starts_with("se.")) %>%
+        tidyr::separate(col = "stat_resp", c("stat", "response"), sep="\\.") %>%
+        tidyr::spread(key = "stat", value)
       # nn <-  c("response", nn)
     }
     ret_fe <-  ret_fe_prep %>%
-      rename(estimate = effect, std.error = se) %>% 
+      rename(estimate = effect, std.error = se) %>%
       select(contains("response"), everything()) %>%
       # fix_data_frame(nn) %>%
       mutate(statistic = estimate / std.error) %>%
-      mutate(p.value = 2 * (1 - stats::pt(statistic, df = N)))  
-    
+      mutate(p.value = 2 * (1 - stats::pt(statistic, df = N)))
+
     if (conf.int) {
-      
+
       crit_val_low <- stats::qnorm(1 - (1 - conf.level) / 2)
       crit_val_high <- stats::qnorm(1 - (1 - conf.level) / 2)
-      
+
       ret_fe <- ret_fe %>%
         mutate(
           conf.low = estimate - crit_val_low * std.error,
@@ -111,35 +111,35 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, robust 
 
 #' @templateVar class felm
 #' @template title_desc_augment
-#' 
+#'
 #' @inherit tidy.felm params examples
-#' @template param_data 
-#' 
+#' @template param_data
+#'
 #' @evalRd return_augment()
-#' 
+#'
 #' @export
 #' @family felm tidiers
 #' @seealso [augment()], [lfe::felm()]
 augment.felm <- function(x, data = model.frame(x), ...) {
   has_multi_response <- length(x$lhs) > 1
-  
+
   if (has_multi_response) {
     stop(
       "Augment does not support linear models with multiple responses.",
       call. = FALSE
-    )  
-  } 
+    )
+  }
   df <- as_broom_tibble(data)
   mutate(df, .fitted = x$fitted.values, .resid = x$residuals)
-  
-  
+
+
 }
 
 #' @templateVar class felm
 #' @template title_desc_glance
-#' 
+#'
 #' @inherit tidy.felm params examples
-#' 
+#'
 #' @evalRd return_glance(
 #'   "r.squared",
 #'   "adj.r.squared",
@@ -153,15 +153,15 @@ augment.felm <- function(x, data = model.frame(x), ...) {
 #'
 #' @export
 glance.felm <- function(x, ...) {
-  
+
   has_multi_response <- length(x$lhs) > 1
-  
+
   if(has_multi_response) {
     stop(
       "Glance does not support linear models with multiple responses.",
       call. = FALSE
-    )  
-  } 
+    )
+  }
   ret <- with(
     summary(x),
     tibble(

--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -130,9 +130,7 @@ augment.felm <- function(x, data = model.frame(x), ...) {
     )
   }
   df <- as_broom_tibble(data)
-  mutate(df, .fitted = x$fitted.values, .resid = x$residuals)
-
-
+  mutate(df, .fitted = as.vector(x$fitted.values), .resid = as.vector(x$residuals))
 }
 
 #' @templateVar class felm

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -37,7 +37,7 @@ test_that("tidy.felm", {
   td5 <- tidy(fit, robust = TRUE)
   td6 <- tidy(fit2, robust = TRUE)
   td7 <- tidy(fit2, robust = TRUE, fe = TRUE)
-  
+
   td_multi <- tidy(fit_multi)
 
   check_tidy_output(td1)
@@ -50,39 +50,39 @@ test_that("tidy.felm", {
   check_tidy_output(td_multi)
 
   check_dims(td1, 2, 5)
-  
+
   expect_equal(tidy(fit_multi)[3:4, -1], tidy(fit))
-  expect_equal(dplyr::pull(td5, std.error), 
+  expect_equal(dplyr::pull(td5, std.error),
                as.numeric(lfe:::summary.felm(fit, robust = TRUE)$coef[, "Robust s.e"]))
-  expect_equal(dplyr::pull(td6, std.error), 
+  expect_equal(dplyr::pull(td6, std.error),
                as.numeric(lfe:::summary.felm(fit2, robust = TRUE)$coef[, "Robust s.e"]))
 })
 
 test_that("glance.felm", {
   gl <- glance(fit)
   gl2 <- glance(fit2)
-  
+
   check_glance_outputs(gl, gl2)
   check_dims(gl, expected_cols = 8)
-  
+
   expect_error(glance(fit_multi), "Glance does not support linear models with multiple responses.")
 
 })
 
 test_that("augment.felm", {
-  
+
   check_augment_function(
     aug = augment.felm,
     model = fit,
     data = df
   )
-  
+
   check_augment_function(
     aug = augment.felm,
     model = fit2,
     data = df
   )
-  
+
   check_augment_function(
     aug = augment.felm,
     model = fit_form,

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -89,4 +89,10 @@ test_that("augment.felm", {
     data = df
   )
   expect_error(augment(fit_multi), "Augment does not support linear models with multiple responses.")
+
+  # Ensure that the .resid and .fitted columns are basic columns, not matrix
+  aug <- augment(fit)
+  expect_false(inherits(aug$.resid, "matrix"))
+  expect_false(inherits(aug$.fitted, "matrix"))
+  expect_null(c(colnames(aug$.resid), colnames(aug$.fitted)))
 })


### PR DESCRIPTION
The objects returned in the `felm` in as `fitted.values` and `residuals` are one-column matrices, not vectors. data.frames can hold these, and they work for most applications
The main benefit is nicer colnames on the `.resid` and `.fitted` output (see #828).

I had trouble running all the tests, but the `test-lfe.R` tests pass.

Fixes #828