### PR TITLE
new url for tidymodels.org

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -287,8 +287,7 @@ Description: Summarizes key information about statistical
     observations to a dataset, such as fitted values or influence
     measures.
 License: MIT + file LICENSE
-URL: https://broom.tidyverse.org/,
-    http://github.com/tidymodels/broom
+URL: https://broom.tidymodels.org/, http://github.com/tidymodels/broom
 BugReports: http://github.com/tidymodels/broom/issues
 Depends:
     R (>= 3.1)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,11 @@
-url: http://broom.tidyverse.org
+url: https://broom.tidymodels.org
 
 template:
   package: tidytemplate
+  params:
+    part_of: <a href="https://tidymodels.org">tidymodels</a>
+    footer: broom is a part of the <strong>tidymodels</strong> ecosystem, a collection of modeling packages designed with common APIs and a shared philosophy.
+
 default_assets: false
 
 home:


### PR DESCRIPTION
Once I get the CNAME entry changed, we can merge this and use the new url. I'll update here when the PR can be merged. We are also getting a redirect for the current url. 

It will also require 3 manual changes to the repos settings after merge:

 * change the website settings on the repo's front page
 * change `Settings : GitHub Pages : Custom domain`
 * change `Settings : GitHub Pages : Enforce HTTPS`