### PR TITLE
Updates to fixest tidiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -534,7 +534,7 @@ Suggests:
     emmeans,
     epiR,
     ergm,
-    fixest (>= 0.3.1),
+    fixest (>= 0.5.0),
     gam (>= 1.15),
     gamlss,
     gamlss.data,

--- a/man/augment.fixest.Rd
+++ b/man/augment.fixest.Rd
@@ -4,7 +4,14 @@
 \alias{augment.fixest}
 \title{Augment data with information from a(n) fixest object}
 \usage{
-\method{augment}{fixest}(x, data = NULL, newdata = NULL, type.predict = "response", ...)
+\method{augment}{fixest}(
+  x,
+  data = NULL,
+  newdata = NULL,
+  type.predict = c("link", "response"),
+  type.residuals = c("response", "deviance", "pearson", "working"),
+  ...
+)
 }
 \arguments{
 \item{x}{A \code{fixest} object returned from any of the \code{fixest} estimators}
@@ -23,7 +30,11 @@ that nothing has been passed to \code{newdata}. If \code{newdata} is specified,
 the \code{data} argument will be ignored.}
 
 \item{type.predict}{Passed to \code{\link[fixest:predict.fixest]{predict.fixest}}
-\code{type} argument. Defaults to \code{"link"} (like \code{glm.predict}).}
+\code{type} argument. Defaults to \code{"link"} (like \code{predict.glm}).}
+
+\item{type.residuals}{Passed to \code{\link[fixest:residuals.fixest]{predict.fixest}}
+\code{type} argument. Defaults to \code{"response"} (like \code{residuals.lm}, but unlike
+\code{residuals.glm}).}
 
 \item{...}{Additional arguments passed to \code{summary} and \code{confint}. Important
 arguments are \code{se} and \code{cluster}. Other arguments are \code{dof}, \code{exact_dof},
@@ -107,7 +118,7 @@ augment(gravity_pois, trade)
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[fixest:feglm]{fixest::feglm()}}, \code{\link[fixest:femlm]{fixest::femlm()}}, \code{\link[fixest:feols]{fixest::feols()}}
 
-Other fixest tidiers: 
+Other fixest tidiers:
 \code{\link{tidy.fixest}()}
 }
 \concept{fixest tidiers}

--- a/man/glance.fixest.Rd
+++ b/man/glance.fixest.Rd
@@ -35,7 +35,10 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \note{
-The columns of the result depend on the type of model estimated.
+All columns listed below will be returned, but some will be \code{NA},
+depending on the type of model estimated. \code{sigma}, \code{r.squared},
+\code{adj.r.squared}, and \code{within.r.squared} will be NA for any model other than
+\code{feols}. \code{pseudo.r.squared} will be NA for \code{feols}.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
- Fix a bug in `fixest.augment` with new data: now correctly return predictions (previously returned residuals)
- Clarify allowed types of predictions and residuals
- The `residuals.fixest` method was introduced in fixest v0.5.0, so increase the required version