### PR TITLE
Fix issue #896

### DIFF
--- a/R/stats-lm-tidiers.R
+++ b/R/stats-lm-tidiers.R
@@ -40,6 +40,11 @@
 #'   head(6) %>%
 #'   mutate(wt = wt + 1)
 #' augment(mod, newdata = newdata)
+#' 
+#' # predict on new data without outcome variable. Output does not include .resid
+#' newdata <- newdata %>%
+#'   select(-mpg)
+#' augment(mod, newdata = newdata)
 #'
 #' au <- augment(mod, data = mtcars)
 #'

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -362,7 +362,7 @@ augment_newdata <- function(x, data, newdata, .se_fit, ...) {
   passed_newdata <- !is.null(newdata)
   df <- if (passed_newdata) newdata else data
   df <- as_augment_tibble(df)
-  # Check if response variable in newdata:
+  # Check if response variable is in newdata:
   response_var_in_newdata <- x$call %>%
     all.vars() %>%
     .[[1]] %>%
@@ -400,8 +400,8 @@ augment_newdata <- function(x, data, newdata, .se_fit, ...) {
       unname()
   }
 
-  # If response variable not included in newdata, remove response variable
-  # attribute from x
+  # If response variable is not included in newdata, remove response variable
+  # attribute from model object
   if (!response_var_in_newdata) {
     x <- x %>%
       terms() %>%

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -362,6 +362,11 @@ augment_newdata <- function(x, data, newdata, .se_fit, ...) {
   passed_newdata <- !is.null(newdata)
   df <- if (passed_newdata) newdata else data
   df <- as_augment_tibble(df)
+  # Check if response variable in newdata:
+  response_var_in_newdata <- x$call %>%
+    all.vars() %>%
+    .[[1]] %>%
+    is.element(names(df))
 
   # NOTE: It is important use predict(x, newdata = newdata) rather than
   # predict(x, newdata = df). This is to avoid an edge case breakage
@@ -395,6 +400,14 @@ augment_newdata <- function(x, data, newdata, .se_fit, ...) {
       unname()
   }
 
+  # If response variable not included in newdata, remove response variable
+  # attribute from x
+  if (!response_var_in_newdata) {
+    x <- x %>%
+      terms() %>%
+      delete.response()
+  }
+  
   resp <- safe_response(x, df)
 
   if (!is.null(resp) && is.numeric(resp)) {

--- a/man-roxygen/title_desc_augment.R
+++ b/man-roxygen/title_desc_augment.R
@@ -11,8 +11,10 @@
 #'   `newdata` argument. If the user passes data to the `data` argument,
 #'   it **must** be exactly the data that was used to fit the model
 #'   object. Pass datasets to `newdata` to augment data that was not used
-#'   during model fitting. This still requires that all columns used to fit
-#'   the model are present.
+#'   during model fitting. This still requires that at least all predictor 
+#'   variable columns used to fit the model are present. If the original outcome
+#'   variable used to fit the model is not included in `newdata`, then no
+#'   `.resid` column will be included in the output.
 #'   
 #'   Augment will often behave differently depending on whether `data` or 
 #'   `newdata` is given. This is because there is often information


### PR DESCRIPTION
Attempt at fixing #896. Here is the proposed behavior of `augment.lm()`

``` r
library(tidyverse)
library(broom)
 
# Prep mtcars
mtcars <- mtcars %>%
  rownames_to_column(var = "automobile") %>%
  mutate(cyl = as.factor(cyl)) %>% 
  select(mpg, hp, cyl)

# Fit lm model with y = mpg
mpg_model <- lm(mpg ~ hp + cyl, data = mtcars)

# Use newdata. Output has .resid variable
mtcars %>% 
  augment(mpg_model, newdata = .)
#> # A tibble: 32 x 5
#>      mpg    hp cyl   .fitted  .resid
#>    <dbl> <dbl> <fct>   <dbl>   <dbl>
#>  1  21     110 6        20.0  0.962 
#>  2  21     110 6        20.0  0.962 
#>  3  22.8    93 4        26.4 -3.61  
#>  4  21.4   110 6        20.0  1.36  
#>  5  18.7   175 8        15.9  2.78  
#>  6  18.1   105 6        20.2 -2.06  
#>  7  14.3   245 8        14.2  0.0602
#>  8  24.4    62 4        27.2 -2.76  
#>  9  22.8    95 4        26.4 -3.57  
#> 10  19.2   123 6        19.7 -0.526 
#> # … with 22 more rows

# Use newdata without y. Output does not have .resid variable as expected, and
# no longer has warning message from v0.7.0
mtcars %>% 
  select(-mpg) %>% 
  augment(mpg_model, newdata = .)
#> # A tibble: 32 x 3
#>       hp cyl   .fitted
#>    <dbl> <fct>   <dbl>
#>  1   110 6        20.0
#>  2   110 6        20.0
#>  3    93 4        26.4
#>  4   110 6        20.0
#>  5   175 8        15.9
#>  6   105 6        20.2
#>  7   245 8        14.2
#>  8    62 4        27.2
#>  9    95 4        26.4
#> 10   123 6        19.7
#> # … with 22 more rows
```

<sup>Created on 2020-07-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>