### PR TITLE
Update survival-survfit-tidiers.R

### DIFF
--- a/R/survival-survfit-tidiers.R
+++ b/R/survival-survfit-tidiers.R
@@ -58,7 +58,10 @@ tidy.survfit <- function(x, ...) {
       n.event = c(x$n.event),
       n.censor = c(x$n.censor),
       estimate = c(x$pstate),
-      std.error = c(x$std.err),
+      # standard error obtained from summary(x)$std.err seems 
+      # the correct one, which is different than standard error
+      # of x$std.err
+      std.error = c(summary(x)$std.err),
       conf.high = c(x$upper),
       conf.low = c(x$lower),
       state = rep(x$states, each = nrow(x$pstate))
@@ -72,7 +75,10 @@ tidy.survfit <- function(x, ...) {
       n.event = x$n.event,
       n.censor = x$n.censor,
       estimate = x$surv,
-      std.error = x$std.err,
+      # standard error obtained from summary(x)$std.err seems 
+      # the correct one, which is different than standard error
+      # of x$std.err
+      std.error = summary(x)$std.err,
       conf.high = x$upper,
       conf.low = x$lower
     )


### PR DESCRIPTION
I found that the values of standard error of a sufvfit() object (Kaplan-Meier estimate) depends on whether is is extracting from the sufvit object directly or extracting from the summary(survfit) object. I think the standard error estimates of summary(survfit) object are correct, but tidy(survfit) uses standard error of survfit object. So I suggest to make the changes so tidy() provides correct standard error of Kaplan-Meier estimates.

# Hi!

Thanks for making a pull request to broom! A few things to keep in mind that will probably help this PR be merged more quickly:  

* Have you documented the change in `NEWS.md`?  
* If this is your first time PRing to broom, have you added yourself as a contributor in the `DESCRIPTION`?
* Have you added any new vocabulary to `inst/WORDLIST`? (New vocabulary will be noted in the R-CMD-check from GitHub Actions.)
* Does R-CMD-check pass on GitHub Actions? (Sometimes, checks may not be passing on the main branch already—if that's the case, just try to make sure your changes don't add any additional errors/warnings.) 

If your PR fixes a bug, a [reprex](https://github.com/tidyverse/reprex) of the bug would be much appreciated!

If your PR adds new tidiers for external model objects, please link to prior attempts to add these tidiers to the model-exporting package, and include a reprex of the new tidiers' functionality!

If you're having trouble making any of these requests happen, let us know and we can lend a hand!
