### PR TITLE
Changed `tidy.prcomp()` to be whole numbers (#578) 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -486,7 +486,11 @@ Authors@R:
       person(given = "Matthieu",
              family = "Stigler",
              role = "ctb",
-             email = "Matthieu.Stigler@gmail.com"))
+             email = "Matthieu.Stigler@gmail.com"),
+      person(given = "Deblina",
+             family = "Mukherjee",
+             role = "ctb", 
+             email = "deblina@uchicago.edu"))
 Description: Summarizes key information about statistical
     objects in tidy tibbles. This makes it easy to report results, create
     plots and consistently work with large numbers of models at once.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ To be released as broom 0.7.1.
 * Fixed `newdata` warning message in `augment.*()` output when the `newdata`
 didn't contain the response variable—augment methods no longer expect the 
 response variable in the supplied `newdata` argument. (#897 by @rudeboybert)
+* Multiplied the `tidy.prcomp()` method by 100 so percentages are shown as
+whole numbers instead of decimals (#578 by GegznaV)
 
 # broom 0.7.0
 

--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -107,7 +107,7 @@ tidy.prcomp <- function(x, matrix = "u", ...) {
       new_names = c("std.dev", "percent", "cumulative"),
       new_column = "PC"
     ) %>% 
-      mutate(percent = percent * 100)
+      dplyr::mutate(percent = percent * 100)
   } else if (matrix %in% c("rotation", "variables", "v", "loadings")) {
     labels <- if (is.null(rownames(x$rotation))) {
       1:nrow(x$rotation)

--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -106,7 +106,8 @@ tidy.prcomp <- function(x, matrix = "u", ...) {
       t(summary(x)$importance),
       new_names = c("std.dev", "percent", "cumulative"),
       new_column = "PC"
-    )
+    ) %>% 
+      mutate(percent = percent * 100)
   } else if (matrix %in% c("rotation", "variables", "v", "loadings")) {
     labels <- if (is.null(rownames(x$rotation))) {
       1:nrow(x$rotation)


### PR DESCRIPTION
# Hi!

I've multiplied the `tidy.prcomp()` method by 100 so percentages are shown as whole numbers instead of decimals (as per #578 by GegznaV). The change is documented in `NEWS.md`, I've added myself as a contributor, and R-CMD doesn't seem to have added any additional warnings (though I might be wrong on this, happy to correct if so). 

