### PR TITLE
stats-prcomp clarify doc

### DIFF
--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -44,9 +44,11 @@
 #'
 #'   \item{`PC`}{An integer vector indicating the principal component}
 #'   \item{`std.dev`}{Standard deviation explained by this PC}
-#'   \item{`percent`}{Fraction of variation explained by this component}
+#'   \item{`percent`}{Fraction of variation explained by this component
+#'     (a numeric value between 0 and 1).}
 #'   \item{`cumulative`}{Cumulative fraction of variation explained by
-#'     principle components up to this component.}
+#'     principle components up to this component (a numeric value between 0 and
+#'     1).}
 #'
 #' @details See https://stats.stackexchange.com/questions/134282/relationship-between-svd-and-pca-how-to-use-svd-to-perform-pca
 #'   for information on how to interpret the various tidied matrices. Note


### PR DESCRIPTION
The PR cited below multiplied values by 100 to return "percent". But the maintainers decided that this could introduce breakage. A compromise solution was proposed to improve the documentation.

This very minor PR only changes the doc strings. It closes this issue

https://github.com/tidymodels/broom/issues/578

and this PR:

https://github.com/tidymodels/broom/pull/901

