### PR TITLE
Fix bug with tidy.felm confidence intervals.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,8 @@ adjustment of RMST and other measures (#880 by @vincentarelbundock)
 * Fixed `augment.fixest()` returning residuals in the `.fitted` column. The
 method also now takes a `type.residuals` argument and defaults to the same 
 `type.predict` argument as the `fixest` `predict()` method. (#877 by @karldw)
-* Adjusted the default `robust` argument in `tidy.felm()` to mirror the default
-in `lfe::summary.felm()`. (#818 by @kuriwaki)
+* Fix `tidy.felm` confidence interval bug. Replaces "robust" argument with 
+"se_type"; potential breaking change. (#919 by @grantmcdermott)
 
 # broom 0.7.0
 

--- a/man/augment.felm.Rd
+++ b/man/augment.felm.Rd
@@ -87,8 +87,16 @@ augment(result_felm)
 
 result_felm <- felm(v2 ~ v3 | id + v1, DT)
 tidy(result_felm, fe = TRUE)
-tidy(result_felm, robust = TRUE)
+tidy(result_felm, se.type = "robust") ## Same as default above
+tidy(result_felm, se.type = "iid") ## Non-robust SEs
 augment(result_felm)
+
+## The "se.type" argument is useful for comparing SEs on the fly.
+result_felm <- felm(v2 ~ v3 | id + v1 | 0 | id, DT) ## Cluster by id
+tidy(result_felm, conf.int = TRUE) 
+tidy(result_felm, conf.int = TRUE, se.type = "cluster") ## Same as default above
+tidy(result_felm, conf.int = TRUE, se.type = "robust") ## HC SEs
+tidy(result_felm, se.type = "iid") ## Vanilla SEs
 
 v1 <- DT$v1
 v2 <- DT$v2

--- a/man/augment.felm.Rd
+++ b/man/augment.felm.Rd
@@ -90,15 +90,15 @@ glance(est1)
 ## The "se.type" argument can be used to switch out different standard errors 
 ## types on the fly. In turn, this can be useful exploring the effect of 
 ## different error structures on model inference.
-tidy(est1, se.type = "robust") ## Same as default above
-tidy(est1, se.type = "iid") ## Non-robust SEs
+tidy(est1, se.type = "iid")
+tidy(est1, se.type = "robust")
 
 ## Add clustered SEs (also by month)
 est2 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month | 0 | Month, airquality)
 tidy(est2, conf.int = TRUE) 
-tidy(est2, conf.int = TRUE, se.type = "cluster") ## Same as default above
-tidy(est2, conf.int = TRUE, se.type = "robust") ## HC SEs
-tidy(est2, conf.int = TRUE, se.type = "iid") ## Vanilla SEs
+tidy(est2, conf.int = TRUE, se.type = "cluster")
+tidy(est2, conf.int = TRUE, se.type = "robust")
+tidy(est2, conf.int = TRUE, se.type = "iid")
 }
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[lfe:felm]{lfe::felm()}}

--- a/man/augment.felm.Rd
+++ b/man/augment.felm.Rd
@@ -72,41 +72,33 @@ missing at this time.
 
 library(lfe)
 
-N <- 1e2
-DT <- data.frame(
-  id = sample(5, N, TRUE),
-  v1 = sample(5, N, TRUE),
-  v2 = sample(1e6, N, TRUE),
-  v3 = sample(round(runif(100, max = 100), 4), N, TRUE),
-  v4 = sample(round(runif(100, max = 100), 4), N, TRUE)
-)
+## Use built-in "airquality" dataset
+head(airquality)
 
-result_felm <- felm(v2 ~ v3, DT)
-tidy(result_felm)
-augment(result_felm)
+## No FEs; same as lm()
+est0 <- felm(Ozone ~ Temp + Wind + Solar.R, airquality)
+tidy(est0)
+augment(est0)
 
-result_felm <- felm(v2 ~ v3 | id + v1, DT)
-tidy(result_felm, fe = TRUE)
-tidy(result_felm, se.type = "robust") ## Same as default above
-tidy(result_felm, se.type = "iid") ## Non-robust SEs
-augment(result_felm)
+## Add month fixed effects
+est1 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month, airquality)
+tidy(est1)
+tidy(est1, fe = TRUE)
+augment(est1)
+glance(est1)
 
-## The "se.type" argument is useful for comparing SEs on the fly.
-result_felm <- felm(v2 ~ v3 | id + v1 | 0 | id, DT) ## Cluster by id
-tidy(result_felm, conf.int = TRUE) 
-tidy(result_felm, conf.int = TRUE, se.type = "cluster") ## Same as default above
-tidy(result_felm, conf.int = TRUE, se.type = "robust") ## HC SEs
-tidy(result_felm, se.type = "iid") ## Vanilla SEs
+## The "se.type" argument can be used to switch out different standard errors 
+## types on the fly. In turn, this can be useful exploring the effect of 
+## different error structures on model inference.
+tidy(est1, se.type = "robust") ## Same as default above
+tidy(est1, se.type = "iid") ## Non-robust SEs
 
-v1 <- DT$v1
-v2 <- DT$v2
-v3 <- DT$v3
-id <- DT$id
-result_felm <- felm(v2 ~ v3 | id + v1)
-
-tidy(result_felm)
-augment(result_felm)
-glance(result_felm)
+## Add clustered SEs (also by month)
+est2 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month | 0 | Month, airquality)
+tidy(est2, conf.int = TRUE) 
+tidy(est2, conf.int = TRUE, se.type = "cluster") ## Same as default above
+tidy(est2, conf.int = TRUE, se.type = "robust") ## HC SEs
+tidy(est2, conf.int = TRUE, se.type = "iid") ## Vanilla SEs
 }
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[lfe:felm]{lfe::felm()}}

--- a/man/glance.felm.Rd
+++ b/man/glance.felm.Rd
@@ -43,41 +43,33 @@ of the appropriate type.
 
 library(lfe)
 
-N <- 1e2
-DT <- data.frame(
-  id = sample(5, N, TRUE),
-  v1 = sample(5, N, TRUE),
-  v2 = sample(1e6, N, TRUE),
-  v3 = sample(round(runif(100, max = 100), 4), N, TRUE),
-  v4 = sample(round(runif(100, max = 100), 4), N, TRUE)
-)
+## Use built-in "airquality" dataset
+head(airquality)
 
-result_felm <- felm(v2 ~ v3, DT)
-tidy(result_felm)
-augment(result_felm)
+## No FEs; same as lm()
+est0 <- felm(Ozone ~ Temp + Wind + Solar.R, airquality)
+tidy(est0)
+augment(est0)
 
-result_felm <- felm(v2 ~ v3 | id + v1, DT)
-tidy(result_felm, fe = TRUE)
-tidy(result_felm, se.type = "robust") ## Same as default above
-tidy(result_felm, se.type = "iid") ## Non-robust SEs
-augment(result_felm)
+## Add month fixed effects
+est1 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month, airquality)
+tidy(est1)
+tidy(est1, fe = TRUE)
+augment(est1)
+glance(est1)
 
-## The "se.type" argument is useful for comparing SEs on the fly.
-result_felm <- felm(v2 ~ v3 | id + v1 | 0 | id, DT) ## Cluster by id
-tidy(result_felm, conf.int = TRUE) 
-tidy(result_felm, conf.int = TRUE, se.type = "cluster") ## Same as default above
-tidy(result_felm, conf.int = TRUE, se.type = "robust") ## HC SEs
-tidy(result_felm, se.type = "iid") ## Vanilla SEs
+## The "se.type" argument can be used to switch out different standard errors 
+## types on the fly. In turn, this can be useful exploring the effect of 
+## different error structures on model inference.
+tidy(est1, se.type = "robust") ## Same as default above
+tidy(est1, se.type = "iid") ## Non-robust SEs
 
-v1 <- DT$v1
-v2 <- DT$v2
-v3 <- DT$v3
-id <- DT$id
-result_felm <- felm(v2 ~ v3 | id + v1)
-
-tidy(result_felm)
-augment(result_felm)
-glance(result_felm)
+## Add clustered SEs (also by month)
+est2 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month | 0 | Month, airquality)
+tidy(est2, conf.int = TRUE) 
+tidy(est2, conf.int = TRUE, se.type = "cluster") ## Same as default above
+tidy(est2, conf.int = TRUE, se.type = "robust") ## HC SEs
+tidy(est2, conf.int = TRUE, se.type = "iid") ## Vanilla SEs
 }
 \value{
 A \code{\link[tibble:tibble]{tibble::tibble()}} with exactly one row and columns:

--- a/man/glance.felm.Rd
+++ b/man/glance.felm.Rd
@@ -58,8 +58,16 @@ augment(result_felm)
 
 result_felm <- felm(v2 ~ v3 | id + v1, DT)
 tidy(result_felm, fe = TRUE)
-tidy(result_felm, robust = TRUE)
+tidy(result_felm, se.type = "robust") ## Same as default above
+tidy(result_felm, se.type = "iid") ## Non-robust SEs
 augment(result_felm)
+
+## The "se.type" argument is useful for comparing SEs on the fly.
+result_felm <- felm(v2 ~ v3 | id + v1 | 0 | id, DT) ## Cluster by id
+tidy(result_felm, conf.int = TRUE) 
+tidy(result_felm, conf.int = TRUE, se.type = "cluster") ## Same as default above
+tidy(result_felm, conf.int = TRUE, se.type = "robust") ## HC SEs
+tidy(result_felm, se.type = "iid") ## Vanilla SEs
 
 v1 <- DT$v1
 v2 <- DT$v2

--- a/man/glance.felm.Rd
+++ b/man/glance.felm.Rd
@@ -61,15 +61,15 @@ glance(est1)
 ## The "se.type" argument can be used to switch out different standard errors 
 ## types on the fly. In turn, this can be useful exploring the effect of 
 ## different error structures on model inference.
-tidy(est1, se.type = "robust") ## Same as default above
-tidy(est1, se.type = "iid") ## Non-robust SEs
+tidy(est1, se.type = "iid")
+tidy(est1, se.type = "robust")
 
 ## Add clustered SEs (also by month)
 est2 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month | 0 | Month, airquality)
 tidy(est2, conf.int = TRUE) 
-tidy(est2, conf.int = TRUE, se.type = "cluster") ## Same as default above
-tidy(est2, conf.int = TRUE, se.type = "robust") ## HC SEs
-tidy(est2, conf.int = TRUE, se.type = "iid") ## Vanilla SEs
+tidy(est2, conf.int = TRUE, se.type = "cluster")
+tidy(est2, conf.int = TRUE, se.type = "robust")
+tidy(est2, conf.int = TRUE, se.type = "iid")
 }
 \value{
 A \code{\link[tibble:tibble]{tibble::tibble()}} with exactly one row and columns:

--- a/man/tidy.felm.Rd
+++ b/man/tidy.felm.Rd
@@ -75,15 +75,15 @@ glance(est1)
 ## The "se.type" argument can be used to switch out different standard errors 
 ## types on the fly. In turn, this can be useful exploring the effect of 
 ## different error structures on model inference.
-tidy(est1, se.type = "robust") ## Same as default above
-tidy(est1, se.type = "iid") ## Non-robust SEs
+tidy(est1, se.type = "iid")
+tidy(est1, se.type = "robust")
 
 ## Add clustered SEs (also by month)
 est2 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month | 0 | Month, airquality)
 tidy(est2, conf.int = TRUE) 
-tidy(est2, conf.int = TRUE, se.type = "cluster") ## Same as default above
-tidy(est2, conf.int = TRUE, se.type = "robust") ## HC SEs
-tidy(est2, conf.int = TRUE, se.type = "iid") ## Vanilla SEs
+tidy(est2, conf.int = TRUE, se.type = "cluster")
+tidy(est2, conf.int = TRUE, se.type = "robust")
+tidy(est2, conf.int = TRUE, se.type = "iid")
 }
 \seealso{
 \code{\link[=tidy]{tidy()}}, \code{\link[lfe:felm]{lfe::felm()}}

--- a/man/tidy.felm.Rd
+++ b/man/tidy.felm.Rd
@@ -31,8 +31,9 @@ fixed effects. Defaults to \code{FALSE}.}
 \item{se.type}{Character indicating the type of standard errors. Defaults to
 using those of the underlying felm() model object, e.g. clustered errors
 for models that were provided a cluster specification. Users can override
-these defaults (say, to explore the effect of different error structures
-on model inference) by specifying an appropriate alternative.}
+these defaults by specifying an appropriate alternative: "iid" (for
+homoskedastic errors), "robust" (for Eicker-Huber-White robust errors), or
+"cluster" (for clustered standard errors; if the model object supports it).}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be
@@ -56,41 +57,33 @@ specify which components to return.
 
 library(lfe)
 
-N <- 1e2
-DT <- data.frame(
-  id = sample(5, N, TRUE),
-  v1 = sample(5, N, TRUE),
-  v2 = sample(1e6, N, TRUE),
-  v3 = sample(round(runif(100, max = 100), 4), N, TRUE),
-  v4 = sample(round(runif(100, max = 100), 4), N, TRUE)
-)
+## Use built-in "airquality" dataset
+head(airquality)
 
-result_felm <- felm(v2 ~ v3, DT)
-tidy(result_felm)
-augment(result_felm)
+## No FEs; same as lm()
+est0 <- felm(Ozone ~ Temp + Wind + Solar.R, airquality)
+tidy(est0)
+augment(est0)
 
-result_felm <- felm(v2 ~ v3 | id + v1, DT)
-tidy(result_felm, fe = TRUE)
-tidy(result_felm, se.type = "robust") ## Same as default above
-tidy(result_felm, se.type = "iid") ## Non-robust SEs
-augment(result_felm)
+## Add month fixed effects
+est1 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month, airquality)
+tidy(est1)
+tidy(est1, fe = TRUE)
+augment(est1)
+glance(est1)
 
-## The "se.type" argument is useful for comparing SEs on the fly.
-result_felm <- felm(v2 ~ v3 | id + v1 | 0 | id, DT) ## Cluster by id
-tidy(result_felm, conf.int = TRUE) 
-tidy(result_felm, conf.int = TRUE, se.type = "cluster") ## Same as default above
-tidy(result_felm, conf.int = TRUE, se.type = "robust") ## HC SEs
-tidy(result_felm, se.type = "iid") ## Vanilla SEs
+## The "se.type" argument can be used to switch out different standard errors 
+## types on the fly. In turn, this can be useful exploring the effect of 
+## different error structures on model inference.
+tidy(est1, se.type = "robust") ## Same as default above
+tidy(est1, se.type = "iid") ## Non-robust SEs
 
-v1 <- DT$v1
-v2 <- DT$v2
-v3 <- DT$v3
-id <- DT$id
-result_felm <- felm(v2 ~ v3 | id + v1)
-
-tidy(result_felm)
-augment(result_felm)
-glance(result_felm)
+## Add clustered SEs (also by month)
+est2 <- felm(Ozone ~ Temp + Wind + Solar.R  | Month | 0 | Month, airquality)
+tidy(est2, conf.int = TRUE) 
+tidy(est2, conf.int = TRUE, se.type = "cluster") ## Same as default above
+tidy(est2, conf.int = TRUE, se.type = "robust") ## HC SEs
+tidy(est2, conf.int = TRUE, se.type = "iid") ## Vanilla SEs
 }
 \seealso{
 \code{\link[=tidy]{tidy()}}, \code{\link[lfe:felm]{lfe::felm()}}

--- a/man/tidy.felm.Rd
+++ b/man/tidy.felm.Rd
@@ -11,7 +11,7 @@
   conf.int = FALSE,
   conf.level = 0.95,
   fe = FALSE,
-  robust = !is.null(x$clustervar),
+  se.type = c("default", "iid", "robust", "cluster"),
   ...
 )
 }
@@ -28,9 +28,11 @@ Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
 \item{fe}{Logical indicating whether or not to include estimates of
 fixed effects. Defaults to \code{FALSE}.}
 
-\item{robust}{Logical indicating robust or clustered SEs should be used.
-Following lfe::summary.felm, it defaults to \code{FALSE} when there is no
-clustering variable, and defaults to \code{TRUE} when there is one.}
+\item{se.type}{Character indicating the type of standard errors. Defaults to
+using those of the underlying felm() model object, e.g. clustered errors
+for models that were provided a cluster specification. Users can override
+these defaults (say, to explore the effect of different error structures
+on model inference) by specifying an appropriate alternative.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be
@@ -69,8 +71,16 @@ augment(result_felm)
 
 result_felm <- felm(v2 ~ v3 | id + v1, DT)
 tidy(result_felm, fe = TRUE)
-tidy(result_felm, robust = TRUE)
+tidy(result_felm, se.type = "robust") ## Same as default above
+tidy(result_felm, se.type = "iid") ## Non-robust SEs
 augment(result_felm)
+
+## The "se.type" argument is useful for comparing SEs on the fly.
+result_felm <- felm(v2 ~ v3 | id + v1 | 0 | id, DT) ## Cluster by id
+tidy(result_felm, conf.int = TRUE) 
+tidy(result_felm, conf.int = TRUE, se.type = "cluster") ## Same as default above
+tidy(result_felm, conf.int = TRUE, se.type = "robust") ## HC SEs
+tidy(result_felm, se.type = "iid") ## Vanilla SEs
 
 v1 <- DT$v1
 v2 <- DT$v2

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -40,11 +40,11 @@ test_that("tidy.felm", {
   td2 <- tidy(fit2, conf.int = TRUE, fe = TRUE, fe.error = FALSE)
   td3 <- tidy(fit2, conf.int = TRUE, fe = TRUE)
   td4 <- tidy(fit_form)
-  td5 <- tidy(fit, robust = TRUE)
-  td6 <- tidy(fit2, robust = TRUE)
-  td7 <- tidy(fit2, robust = TRUE, fe = TRUE)
+  td5 <- tidy(fit, se = "robust")
+  td6 <- tidy(fit2, se = "robust")
+  td7 <- tidy(fit2, se = "robust", fe = TRUE)
   td8 <- tidy(fit3)
-  td9 <- tidy(fit3, robust = FALSE)
+  td9 <- tidy(fit3, se = "iid")
   
   
   td_multi <- tidy(fit_multi)


### PR DESCRIPTION
Fixes #919 

One important note before I show some examples: This PR introduces a potential breaking change for some users, since I replaced the `tidy.felm(... robust = TRUE)` argument with a more flexible `tidy.felm(... se.type = c("default", "iid", "robust", "cluster"))` argument. The reason is that I couldn't see another way to sensibly handle the different cases where we might want to specify a particular SE structure and resulting confidence interval. (Sorry @kuriwaki!)

(The gory details involve the fact that `felm.tidy` relies on both `summary.felm` and `confint.felm` underneath the hood... but these take and report slightly different arguments. Happy to expand on that if needed.)

The good news is that users who just relied on the defaults &mdash; the vast majority, I expect &mdash; will be unaffected.

### Examples

``` r
devtools::load_all('~/Documents/Projects/broom/')
#> Loading broom
library(lfe)
#> Loading required package: Matrix

## Load example data and regs from felm() help documentation
example(felm, echo = FALSE)


# Non-clustered felm object -----------------------------------------------

# defaults
confint(est)
#>        2.5 %    97.5 %
#> x  0.9575300 1.0806284
#> x2 0.4939149 0.6158109
tidy(est, conf.int = TRUE) %>% select(term, contains('conf')) %>% as.data.frame()
#>   term  conf.low conf.high
#> 1    x 0.9575300 1.0806284
#> 2   x2 0.4939149 0.6158109

## robust SEs (same as default for non-clustered felm objects)
confint(est, type = "robust")
#>        2.5 %    97.5 %
#> x  0.9600680 1.0780904
#> x2 0.4940202 0.6157056
tidy(est, conf.int = TRUE, se.type = 'robust') %>% as.data.frame()
#>   term  estimate  std.error statistic       p.value  conf.low conf.high
#> 1    x 1.0190792 0.03007057  33.88958 1.620870e-166 0.9600680 1.0780904
#> 2   x2 0.5548629 0.03100386  17.89658  4.401289e-62 0.4940202 0.6157056

## iid
confint(est, type = "iid")
#>        2.5 %    97.5 %
#> x  0.9575300 1.0806284
#> x2 0.4939149 0.6158109
tidy(est, conf.int = TRUE, se.type = 'iid') %>% as.data.frame()
#>   term  estimate  std.error statistic       p.value  conf.low conf.high
#> 1    x 1.0190792 0.03136390  32.49211 4.255151e-157 0.9575300 1.0806284
#> 2   x2 0.5548629 0.03105755  17.86564  6.677991e-62 0.4939149 0.6158109

## clustered SEs (will trigger a warning for tidy)
confint(est, type = "cluster")
#>    2.5 % 97.5 %
#> x     NA     NA
#> x2    NA     NA
tidy(est, conf.int = TRUE, se.type = 'cluster') %>% as.data.frame()
#> Warning in tidy.felm(est, conf.int = TRUE, se.type = "cluster"): Clustered SEs requested, but weren't calculated in underlying model object. Reverting to default SEs.
#>   term  estimate  std.error statistic       p.value  conf.low conf.high
#> 1    x 1.0190792 0.03007057  33.88958 1.620870e-166 0.9575300 1.0806284
#> 2   x2 0.5548629 0.03100386  17.89658  4.401289e-62 0.4939149 0.6158109


# Clustered felm object ---------------------------------------------------


## defaults (i.e. clustered SEs)
confint(est_cl)
#>        2.5 %    97.5 %
#> x  0.9327042 1.1476205
#> x2 0.4048214 0.5757909
tidy(est_cl, conf.int = TRUE) %>% as.data.frame()
#>   term  estimate  std.error statistic      p.value  conf.low conf.high
#> 1    x 1.0401624 0.05475790  18.99566 1.300984e-68 0.9327042 1.1476205
#> 2   x2 0.4903062 0.04356082  11.25567 1.056241e-27 0.4048214 0.5757909
tidy(est_cl, conf.int = TRUE, se.type = 'cluster') %>% as.data.frame() ## same
#>   term  estimate  std.error statistic      p.value  conf.low conf.high
#> 1    x 1.0401624 0.05475790  18.99566 1.300984e-68 0.9327042 1.1476205
#> 2   x2 0.4903062 0.04356082  11.25567 1.056241e-27 0.4048214 0.5757909

## iid
confint(est_cl, type = 'iid')
#>        2.5 %    97.5 %
#> x  0.9444389 1.1358858
#> x2 0.3955178 0.5850946
tidy(est_cl, conf.int = TRUE, se.type = 'iid') %>% as.data.frame()
#>   term  estimate  std.error statistic      p.value  conf.low conf.high
#> 1    x 1.0401624 0.04877818  21.32434 5.457962e-83 0.9444389 1.1358858
#> 2   x2 0.4903062 0.04830173  10.15090 4.497101e-23 0.3955178 0.5850946

## robust
confint(est_cl, type = 'robust')
#>        2.5 %   97.5 %
#> x  0.9336814 1.146643
#> x2 0.3952664 0.585346
tidy(est_cl, conf.int = TRUE, se.type = 'robust') %>% as.data.frame()
#>   term  estimate  std.error statistic      p.value  conf.low conf.high
#> 1    x 1.0401624 0.05475790  18.99566 1.300984e-68 0.9336814  1.146643
#> 2   x2 0.4903062 0.04356082  11.25567 1.056241e-27 0.3952664  0.585346


# Multi-response object ---------------------------------------------------

y2 <- 0.1*x + 0.5*x2 + id.eff[id] + firm.eff[firm] + u
est_multi <- felm(y+y2 ~ x+x2| id + firm)

confint(est_multi)
#>            2.5 %     97.5 %
#> y:x   -0.6193465 -0.4334547
#> y:x2   0.4816079  0.6656839
#> y2:x   0.0575300  0.1806284
#> y2:x2  0.4939149  0.6158109
tidy(est_multi, conf.int = TRUE) %>% as.data.frame()
#>   response term   estimate  std.error  statistic      p.value   conf.low  conf.high
#> 1        y    x -0.5264006 0.04736283 -11.114214 4.333891e-27 -0.6193465 -0.4334547
#> 2        y    x -0.5264006 0.04736283 -11.114214 4.333891e-27  0.0575300  0.1806284
#> 3        y   x2  0.5736459 0.04690021  12.231202 4.362013e-32  0.4816079  0.6656839
#> 4        y   x2  0.5736459 0.04690021  12.231202 4.362013e-32  0.4939149  0.6158109
#> 5       y2    x  0.1190792 0.03136390   3.796698 1.557801e-04 -0.6193465 -0.4334547
#> 6       y2    x  0.1190792 0.03136390   3.796698 1.557801e-04  0.0575300  0.1806284
#> 7       y2   x2  0.5548629 0.03105755  17.865639 6.677991e-62  0.4816079  0.6656839
#> 8       y2   x2  0.5548629 0.03105755  17.865639 6.677991e-62  0.4939149  0.6158109
```

<sup>Created on 2020-08-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
