### PR TITLE
Fix issue 923

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -490,7 +490,12 @@ Authors@R:
 	  person(given = "R. Willem",
              family = "Vervoort",
              role = "ctb",
-             email = "Willemvervoort@gmail.com"))
+             email = "Willemvervoort@gmail.com"),
+    person(given = "Claus O.",
+             family = "Wilke",
+             role = c("cbt"),
+             email = "wilke@austin.utexas.edu",
+             comment = c(ORCID = "0000-0002-7470-9261")))
 Description: Summarizes key information about statistical
     objects in tidy tibbles. This makes it easy to report results, create
     plots and consistently work with large numbers of models at once.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 To be released as broom 0.7.1.
 
+* Fixed a bug related to `tidy.prcomp()` returning incorrect output
+for `matrix = "v"`. (#923 by @clauswilke)
 * Extended the `glance.aov()` method to include an `r.squared` column!
 * Fixed `newdata` warning message in `augment.*()` output when the `newdata`
 didn't contain the response variable—augment methods no longer expect the 

--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -123,7 +123,7 @@ tidy.prcomp <- function(x, matrix = "u", ...) {
       tibble::remove_rownames() %>%
       as.data.frame()
     ret <- data.frame(
-      label = rep(labels, times = ncomp),
+      label = rep(labels, each = ncomp),
       variables,
       stringsAsFactors = FALSE
     )

--- a/tests/testthat/test-stats-prcomp.R
+++ b/tests/testthat/test-stats-prcomp.R
@@ -20,6 +20,13 @@ test_that("tidy.prcomp", {
   expect_identical(tidy(pc, matrix = "eigenvalues"), td)
 
   td2 <- tidy(pc, matrix = "v")
+  
+  # columns `column` and `PC` form all
+  # possible unique combinations
+  expect_identical(
+    length(unique(paste(td2$column, td2$PC))),
+    length(unique(td2$column)) * length(unique(td2$PC))
+  )
 
   check_tidy_output(td2, strict = FALSE)
   check_dims(td2, 16, 3)


### PR DESCRIPTION
This fixes #923:

    library(broom)
    library(dplyr)
    library(tidyr)

    iris_pca <- iris %>%
      select(-Species) %>%
      scale() %>%
      prcomp()

    # output generated by tidy.prcomp()
    tidy(iris_pca, matrix = "rotation")
    #> # A tibble: 16 x 3
    #>    column          PC   value
    #>    <chr>        <dbl>   <dbl>
    #>  1 Sepal.Length     1  0.521 
    #>  2 Sepal.Length     2 -0.377 
    #>  3 Sepal.Length     3  0.720 
    #>  4 Sepal.Length     4  0.261 
    #>  5 Sepal.Width      1 -0.269 
    #>  6 Sepal.Width      2 -0.923 
    #>  7 Sepal.Width      3 -0.244 
    #>  8 Sepal.Width      4 -0.124 
    #>  9 Petal.Length     1  0.580 
    #> 10 Petal.Length     2 -0.0245
    #> 11 Petal.Length     3 -0.142 
    #> 12 Petal.Length     4 -0.801 
    #> 13 Petal.Width      1  0.565 
    #> 14 Petal.Width      2 -0.0669
    #> 15 Petal.Width      3 -0.634 
    #> 16 Petal.Width      4  0.524

    # for comparison
    iris_pca$rotation
    #>                     PC1         PC2        PC3        PC4
    #> Sepal.Length  0.5210659 -0.37741762  0.7195664  0.2612863
    #> Sepal.Width  -0.2693474 -0.92329566 -0.2443818 -0.1235096
    #> Petal.Length  0.5804131 -0.02449161 -0.1421264 -0.8014492
    #> Petal.Width   0.5648565 -0.06694199 -0.6342727  0.5235971

<sup>Created on 2020-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>