### PR TITLE
Map `effect.size` to `estimate` in emmeans tidiers

### DIFF
--- a/R/emmeans-tidiers.R
+++ b/R/emmeans-tidiers.R
@@ -183,6 +183,7 @@ tidy_emmeans_summary <- function(x, null.value = NULL, term_names = NULL) {
     "emmean" = "estimate",
     "pmmean" = "estimate",
     "prediction" = "estimate",
+    "effect.size" = "estimate",
     "SE" = "std.error",
     "lower.CL" = "conf.low",
     "upper.CL" = "conf.high",


### PR DESCRIPTION
[As of version 1.4.2](https://github.com/rvlenth/emmeans/blob/master/NEWS.md#emmeans-142) `emmeans` provides a new function `eff_size()` that returns an `emmGrid`-object where the column that contains the estimate is named `effect.size`. Because the current tidier has no mapping for this column it is not appropriately renamed in the tiedied output.

~~~r
library("broom")
library("emmeans")
 
fiber.lm <- lm(strength ~ diameter + machine, data = fiber)
emm <- emmeans(fiber.lm, "machine")
es <- eff_size(emm, sigma = sigma(fiber.lm), edf = df.residual(fiber.lm))
es
~~~
~~~
 contrast effect.size    SE df lower.CL upper.CL
 A - B         -0.650 0.650 11   -2.081    0.781
 A - C          0.993 0.726 11   -0.604    2.590
 B - C          1.643 0.800 11   -0.118    3.405

sigma used for effect sizes: 1.595 
Confidence level used: 0.95 
~~~
~~~r
tidy(es)
~~~
~~~
# A tibble: 3 x 7
  level1 level2 effect.size std.error    df conf.low conf.high
  <chr>  <chr>        <dbl>     <dbl> <dbl>    <dbl>     <dbl>
1 A      B           -0.650     0.650    11   -2.08      0.781
2 A      C            0.993     0.726    11   -0.604     2.59 
3 B      C            1.64      0.800    11   -0.118     3.40 
~~~

This pull request adds the missing mapping such that the `effect.size` column in the tidied output is renamed to `estimate`.