### PR TITLE
emmeans tidier can return both std.error and conf.low at the same time

### DIFF
--- a/R/emmeans-tidiers.R
+++ b/R/emmeans-tidiers.R
@@ -208,11 +208,6 @@ tidy_emmeans_summary <- function(x, null.value = NULL, term_names = NULL) {
 
   colnames(ret) <- dplyr::recode(colnames(ret), !!!(repl))
 
-  # Remove std.error if conf.low/high exist
-  if (any(c("conf.low", "conf.high") %in% colnames(ret))) {
-    ret <- select(ret, -std.error)
-  }
-
   # If contrast column exists, add null.value column
   if ("contrast" %in% colnames(ret)) {
     if (length(null.value) < nrow(ret)) null.value <- rep_len(null.value, nrow(ret))

--- a/tests/testthat/test-emmeans.R
+++ b/tests/testthat/test-emmeans.R
@@ -48,9 +48,9 @@ test_that("tidy.lsmobj", {
   tdmd <- tidy(marginal_dashes, conf.int = TRUE)
   tdc <- tidy(contrast(marginal, method = "pairwise"), conf.int = TRUE)
 
-  check_dims(tdm, 6, 7)
-  check_dims(tdmd, 1, 9)
-  check_dims(tdc, 15, 9)
+  check_dims(tdm, 6, 8)
+  check_dims(tdmd, 1, 10)
+  check_dims(tdc, 15, 10)
 })
 
 test_that("ref.grid tidiers work", {
@@ -59,7 +59,7 @@ test_that("ref.grid tidiers work", {
   check_dims(td, 36, 9)
 
   td <- tidy(rg, conf.int = TRUE)
-  check_dims(td, 36, 10)
+  check_dims(td, 36, 11)
 })
 
 test_that("summary_emm tidiers work", {
@@ -80,7 +80,7 @@ test_that("tidy.ref.grid consistency with tidy.TukeyHSD", {
   td_pairs <- lsmeans(amod, ~tension) %>%
     pairs(reverse = TRUE) %>%
     tidy(conf.int = TRUE) %>%
-    dplyr::select(-statistic, -df) %>%
+    dplyr::select(-statistic, -df, -std.error) %>%
     mutate(contrast = gsub(" ", "", contrast))
 
   expect_equal(


### PR DESCRIPTION
`tidy.emmGrid` drops the "std.error" column when `conf.int=TRUE`. This was reported here:

https://github.com/tidymodels/broom/issues/945

This PR removes the 3 lines of code that dropped the `std.error` column (and did nothing else), and adjusts the number of expected columns in tests.

