### PR TITLE
tidy.garch supports confint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 To be released as 0.7.4.
 
 * Add tidiers for `Rchoice` objects (`#961` by `@vincentarelbundock` and `@Nateme16`)
+* tidy.garch can now produce confidence intervals
 
 # broom 0.7.3
 

--- a/R/tseries-tidiers.R
+++ b/R/tseries-tidiers.R
@@ -2,6 +2,7 @@
 #' @template title_desc_tidy
 #'
 #' @param x A `garch` object returned by [tseries::garch()].
+#' @template param_confint
 #' @template param_unused_dots
 #'
 #' @evalRd return_tidy(
@@ -9,7 +10,9 @@
 #'   "estimate",
 #'   "std.error",
 #'   "statistic",
-#'   "p.value"
+#'   "p.value",
+#'   "conf.low",
+#'   "conf.high"
 #' )
 #'
 #' @examples
@@ -27,11 +30,18 @@
 #' @export
 #' @family garch tidiers
 #' @seealso [tidy()], [tseries::garch()]
-tidy.garch <- function(x, ...) {
+tidy.garch <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   s <- summary(x)
   co <- s$coef
   nn <- c("estimate", "std.error", "statistic", "p.value")
-  as_tidy_tibble(co, new_names = nn[1:ncol(co)])
+  ret <- as_tidy_tibble(co, new_names = nn[1:ncol(co)])
+
+  if (conf.int) {
+    ci <- broom_confint_terms(x, level = conf.level)
+    ret <- dplyr::left_join(ret, ci, by = "term")
+  }
+
+  ret
 }
 
 #' @templateVar class garch

--- a/man/tidy.garch.Rd
+++ b/man/tidy.garch.Rd
@@ -5,10 +5,17 @@
 \alias{garch_tidiers}
 \title{Tidy a(n) garch object}
 \usage{
-\method{tidy}{garch}(x, ...)
+\method{tidy}{garch}(x, conf.int = FALSE, conf.level = 0.95, ...)
 }
 \arguments{
 \item{x}{A \code{garch} object returned by \code{\link[tseries:garch]{tseries::garch()}}.}
+
+\item{conf.int}{Logical indicating whether or not to include a confidence
+interval in the tidied output. Defaults to \code{FALSE}.}
+
+\item{conf.level}{The confidence level to use for the confidence interval
+if \code{conf.int = TRUE}. Must be strictly greater than 0 and less than 1.
+Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be
@@ -49,6 +56,8 @@ Other garch tidiers:
 \concept{garch tidiers}
 \value{
 A \code{\link[tibble:tibble]{tibble::tibble()}} with columns:
+  \item{conf.high}{Upper bound on the confidence interval for the estimate.}
+  \item{conf.low}{Lower bound on the confidence interval for the estimate.}
   \item{estimate}{The estimated value of the regression term.}
   \item{p.value}{The two-sided p-value associated with the observed statistic.}
   \item{statistic}{The value of a T-statistic to use in a hypothesis that the regression term is non-zero.}

--- a/tests/testthat/test-tseries.R
+++ b/tests/testthat/test-tseries.R
@@ -18,6 +18,10 @@ test_that("tidy.garch", {
   td <- tidy(fit)
   check_tidy_output(td)
   check_dims(td, 3)
+
+  td <- tidy(fit, conf.int = TRUE, conf.level = .99)
+  check_tidy_output(td)
+  check_dims(td, 3, 7)
 })
 
 test_that("glance.garch", {


### PR DESCRIPTION
`conf.int` and `conf.level` were missing before, as reported here:

https://github.com/tidymodels/broom/issues/568