### PR TITLE
augment.lm influence with zero weights

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 To be released as 0.7.4.
 
 * Add tidiers for `Rchoice` objects (`#961` by `@vincentarelbundock` and `@Nateme16`)
+* `augment.lm` now works when some regression weights are equal to zero (`#965` by `@vincentarelbundock` and `@vnijs`)
 
 # broom 0.7.3
 

--- a/R/stats-lm-tidiers.R
+++ b/R/stats-lm-tidiers.R
@@ -145,9 +145,7 @@ augment.lm <- function(x, data = model.frame(x), newdata = NULL,
   if (is.null(newdata)) {
     tryCatch({
         infl <- influence(x, do.coef = FALSE)
-        df$.std.resid <- rstandard(x, infl = infl) %>% unname()
         df <- add_hat_sigma_cols(df, x, infl)
-        df$.cooksd <- cooks.distance(x, infl = infl) %>% unname()
       },
       error = data_error
     )

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -335,20 +335,26 @@ data_error <- function(cnd) {
 
 safe_response <- purrr::possibly(response, NULL)
 
+
 # in weighted regressions, influence measures should be zero for
 # data points with zero weight
 # helper for augment.lm and augment.glm
 add_hat_sigma_cols <- function(df, x, infl) {
   df$.hat <- 0
   df$.sigma <- 0
+  df$.cooksd <- 0
+  df$.std.resid <- NA
 
   w <- x$weights
   nonzero_idx <- if (is.null(w)) seq_along(df$.hat) else which(w != 0)
 
   df$.hat[nonzero_idx] <- infl$hat %>% unname()
   df$.sigma[nonzero_idx] <- infl$sigma %>% unname()
+  df$.std.resid[nonzero_idx] <- rstandard(x, infl = infl) %>% unname()
+  df$.cooksd[nonzero_idx] <- cooks.distance(x, infl = infl) %>% unname()
   df
 }
+
 
 # adds only the information that can be defined for newdata. no influence
 # measure of anything fun like goes here.

--- a/tests/testthat/test-stats-lm.R
+++ b/tests/testthat/test-stats-lm.R
@@ -13,6 +13,10 @@ fit <- lm(mpg ~ wt, mtcars)
 fit2 <- lm(mpg ~ wt + log(disp), mtcars)
 fit3 <- lm(mpg ~ 1, mtcars)
 
+# zero weights used to break influence columns in augment.lm
+wts <- c(0, rep(1, nrow(mtcars) - 1))
+fit_0wts <- lm(mpg ~ 1, weights = wts, data = mtcars)
+
 # the cyl:qsec term isn't defined for this fit
 na_row_data <- mtcars[c(6, 9, 13:15, 22), ]
 fit_na_row <- lm(mpg ~ cyl * qsec + gear, data = na_row_data)
@@ -64,6 +68,7 @@ test_that("augment.lm", {
     newdata = mtcars
   )
 
+
   check_augment_function(
     aug = augment.lm,
     model = fit2,
@@ -93,5 +98,12 @@ test_that("augment.lm", {
     model = fit_rd,
     data = rd_data,
     newdata = rd_data
+  )
+
+  check_augment_function(
+    aug = augment.lm,
+    model = fit_0wts,
+    data = mtcars,
+    newdata = mtcars
   )
 })


### PR DESCRIPTION
This issue reports that `augment.lm` breaks when some regression weights are equal to zero:

https://github.com/tidymodels/broom/issues/771

This PR fixes that and adds a new test.

The `add_hat_sigma_cols` in `R/utilities.R` was already designed to handle this corner case. I just moved `.std.resid` and `.cooksd` to that function. Cook's is zero when weight is zero because it is a measure of influence. The standardized residuals is set to `NA`.

