### PR TITLE
bug: coxph frailty conf.int

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 To be released as 0.7.4.
 
 * Add tidiers for `Rchoice` objects (`#961` by `@vincentarelbundock` and `@Nateme16`)
+* Fix bug in `tidy.coxph()` related to confidence intervals on penalized/clustered terms (`#966` by `@vincentarelbundock` and `@matthieu-faron`)
 
 # broom 0.7.3
 

--- a/tests/testthat/test-survival-coxph.R
+++ b/tests/testthat/test-survival-coxph.R
@@ -22,12 +22,14 @@ test_that("tidy.coxph", {
   td3 <- tidy(fit2)
   td4 <- tidy(fit3)
   td5 <- tidy(fit3, exponentiate = TRUE)
+  td6 <- tidy(fit3, conf.int = TRUE)
 
   check_tidy_output(td)
   check_tidy_output(td2)
   check_tidy_output(td3)
   check_tidy_output(td4)
   check_tidy_output(td5)
+  check_tidy_output(td6)
 })
 
 test_that("glance.coxph", {

--- a/tests/testthat/test-survival-coxph.R
+++ b/tests/testthat/test-survival-coxph.R
@@ -10,6 +10,10 @@ fit <- coxph(Surv(time, status) ~ age + sex, lung)
 fit2 <- coxph(Surv(time, status) ~ age + sex, lung, robust = TRUE)
 fit3 <- coxph(Surv(time, status) ~ age + sex + frailty(inst), lung)
 
+bladder1 <- bladder[bladder$enum < 5, ] 
+fit4 <- coxph(Surv(stop, event) ~ (rx + size + number) * strata(enum) + 
+                cluster(id), bladder1)
+
 test_that("coxph tidier arguments", {
   check_arguments(tidy.coxph)
   check_arguments(glance.coxph)
@@ -23,6 +27,9 @@ test_that("tidy.coxph", {
   td4 <- tidy(fit3)
   td5 <- tidy(fit3, exponentiate = TRUE)
   td6 <- tidy(fit3, conf.int = TRUE)
+  td7 <- tidy(fit4)
+  td8 <- tidy(fit4, exponentiate = TRUE)
+  td9 <- tidy(fit4, conf.int = TRUE)
 
   check_tidy_output(td)
   check_tidy_output(td2)
@@ -30,13 +37,18 @@ test_that("tidy.coxph", {
   check_tidy_output(td4)
   check_tidy_output(td5)
   check_tidy_output(td6)
+  check_tidy_output(td7)
+  check_tidy_output(td8)
+  check_tidy_output(td9)
 })
 
 test_that("glance.coxph", {
   gl <- glance(fit)
   gl2 <- glance(fit2)
+  gl3 <- glance(fit3)
+  gl4 <- glance(fit4)
 
-  check_glance_outputs(gl, gl2, strict = FALSE)
+  check_glance_outputs(gl, gl2, gl3, gl4, strict = FALSE)
 })
 
 test_that("augment.coxph", {


### PR DESCRIPTION
This Issue reports that `tidy.coxph(conf.int=TRUE)` fails when the model includes a frailty term.

https://github.com/tidymodels/broom/issues/899

The tidier was written in an old style. Moving to a more modern/idiomatic style with `broom_confint_terms` and `exponentiate` appears to fix this issue.

I include a new test.