### PR TITLE
use exponentiate idiom where possible

### DIFF
--- a/R/btergm-tidiers.R
+++ b/R/btergm-tidiers.R
@@ -17,11 +17,6 @@
 #' @aliases btergm_tidiers
 #' @seealso [tidy()], [btergm::btergm()]
 tidy.btergm <- function(x, conf.level = .95, exponentiate = FALSE, ...) {
-  if (exponentiate) {
-    trans <- exp
-  } else {
-    trans <- identity
-  }
 
   co <- btergm::confint(x, level = conf.level)
 
@@ -30,8 +25,9 @@ tidy.btergm <- function(x, conf.level = .95, exponentiate = FALSE, ...) {
     new_names = c("estimate", "conf.low", "conf.high")[1:ncol(co)]
   )
 
-  ret$conf.low <- trans(ret$conf.low)
-  ret$conf.high <- trans(ret$conf.high)
-  ret$estimate <- trans(ret$estimate)
+  if (exponentiate) {
+    ret <- exponentiate(ret)
+  }
+
   as_tibble(ret)
 }

--- a/R/ergm-tidiers.R
+++ b/R/ergm-tidiers.R
@@ -84,12 +84,8 @@ tidy.ergm <- function(x, conf.int = FALSE, conf.level = 0.95,
       warning("Exponentiating but model didn't use log or logit link.")
     }
 
-    ret$estimate <- exp(ret$estimate)
+    ret <- exponentiate(ret)
 
-    if (conf.int) {
-      ret$conf.low <- exp(ret$conf.low)
-      ret$conf.high <- exp(ret$conf.high)
-    }
   }
 
   as_tibble(ret)

--- a/R/nnet-tidiers.R
+++ b/R/nnet-tidiers.R
@@ -77,13 +77,7 @@ tidy.multinom <- function(x, conf.int = FALSE, conf.level = .95,
   }
 
   if (exponentiate) {
-    to_exp <- "estimate"
-
-    if (conf.int) {
-      to_exp <- c(to_exp, "conf.low", "conf.high")
-    }
-
-    ret[, to_exp] <- lapply(ret[, to_exp, drop = FALSE], exp)
+    ret <- exponentiate(ret)
   }
 
   as_tibble(ret)

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -96,7 +96,7 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95,
   }
 
   if (exponentiate) {
-    results <- dplyr::mutate_at(results, dplyr::vars(estimate, conf.low, conf.high), exp)
+    results <- exponentiate(results)
   }
 
   if (!conf.int) {


### PR DESCRIPTION
Code consistency in the use of `exponentiate`. This PR addresses issue https://github.com/tidymodels/broom/issues/867

I grepped through all the tidiers to find non-standard uses of the `exponentiate` argument and I fixed all of them, except for `coxph`, which is dealt with in PR https://github.com/tidymodels/broom/pull/966