### PR TITLE
tidy.coxph and pspline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,7 @@ To be released as 0.7.4.
 * `tidy.emmGrid` can now return `std.error` and `conf.*` columns at the same time. (`#962` by `@vincentarelbundock` and `@jmbarbone`)
 * `tidy.garch` can now produce confidence intervals (`#964` by `@vincentarelbundock` and `@IndrajeetPatil`)
 * `augment.lm` now works when some regression weights are equal to zero (`#965` by `@vincentarelbundock` and `@vnijs`)
-* `tidy.coxph` can now report confidence intervals on models utilizing penalized/clustering terms (`#966` by `@vincentarelbundock` and `@matthieu-faron`)
-* `tidy.coxph` now works when using `pspline` (by `@vincentarelbundock` and `@KZARCA`)
+* `tidy.coxph` can now handle models utilizing penalized/clustering terms (`#966` and `#969` by `@vincentarelbundock`, `@matthieu-faron`, and `@KZARCA`)
 
 # broom 0.7.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ To be released as 0.7.4.
 * `tidy.garch` can now produce confidence intervals (`#964` by `@vincentarelbundock` and `@IndrajeetPatil`)
 * `augment.lm` now works when some regression weights are equal to zero (`#965` by `@vincentarelbundock` and `@vnijs`)
 * `tidy.coxph` can now report confidence intervals on models utilizing penalized/clustering terms (`#966` by `@vincentarelbundock` and `@matthieu-faron`)
+* `tidy.coxph` now works when using `pspline` (by `@vincentarelbundock` and `@KZARCA`)
 
 # broom 0.7.3
 

--- a/R/survival-coxph-tidiers.R
+++ b/R/survival-coxph-tidiers.R
@@ -67,13 +67,13 @@ tidy.coxph <- function(x, exponentiate = FALSE, conf.int = FALSE,
 
   if (!is.null(x$frail)) {
     nn <- c("estimate", "std.error", "statistic", "p.value")
-  } else if (s$used.robust) {
+  } else if (isTRUE(s$used.robust)) {
     nn <- c("estimate", "std.error", "robust.se", "statistic", "p.value")
   } else {
     nn <- c("estimate", "std.error", "statistic", "p.value")
   }
 
-  if (is.null(x$frail)) {
+  if (is.null(x$frail) && is.null(x$penalty)) {
     ret <- as_tidy_tibble(co[, -2, drop = FALSE], new_names = nn)
   } else {
     ret <- as_tidy_tibble(co[, -c(3, 5), drop = FALSE], new_names = nn)

--- a/tests/testthat/test-survival-coxph.R
+++ b/tests/testthat/test-survival-coxph.R
@@ -14,6 +14,9 @@ bladder1 <- bladder[bladder$enum < 5, ]
 fit4 <- coxph(Surv(stop, event) ~ (rx + size + number) * strata(enum) + 
                 cluster(id), bladder1)
 
+# this model does not have summary(x)$used.robust
+fit5 <- coxph(Surv(time, status) ~ age + pspline(nodes), data = colon)
+
 test_that("coxph tidier arguments", {
   check_arguments(tidy.coxph)
   check_arguments(glance.coxph)
@@ -30,6 +33,8 @@ test_that("tidy.coxph", {
   td7 <- tidy(fit4)
   td8 <- tidy(fit4, exponentiate = TRUE)
   td9 <- tidy(fit4, conf.int = TRUE)
+  td10 <- tidy(fit5)
+  td11 <- tidy(fit5, conf.int = TRUE)
 
   check_tidy_output(td)
   check_tidy_output(td2)
@@ -40,6 +45,8 @@ test_that("tidy.coxph", {
   check_tidy_output(td7)
   check_tidy_output(td8)
   check_tidy_output(td9)
+  check_tidy_output(td10)
+  check_tidy_output(td11)
 })
 
 test_that("glance.coxph", {


### PR DESCRIPTION
Issue https://github.com/tidymodels/broom/issues/187 reports that `tidy.coxph` fails when using a penalty through `pspline`.

This PR fixes this bug by modifying two lines of code and adding a test.