### PR TITLE
tidy.multinom accepts matrix response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ To be released as 0.7.4.
 * Fix bug in `tidy.speedglm` on R 4.0.0+ (`#974` by `@uqzwang`)
 * Add `augment.gam` (`#975` and `#645` by `@vincentarelbundock`)
 * Various bug fixes and improvements to documentation and errors.
+* tidy.multinom works with matrix response (`#977` and `#666` by `@vincentarelbundock` and `@atyre2`)
 
 # broom 0.7.3
 

--- a/R/nnet-tidiers.R
+++ b/R/nnet-tidiers.R
@@ -33,22 +33,34 @@
 #' @seealso [tidy()], [nnet::multinom()]
 tidy.multinom <- function(x, conf.int = FALSE, conf.level = .95,
                           exponentiate = FALSE, ...) {
-  col_names <- if (length(x$lev) > 2) colnames(coef(x)) else names(coef(x))
+
+
+  # when the response is a matrix, x$lev is null
+  if (is.null(x$lev)) {
+    n_lev <- ncol(x$residuals)
+  } else {
+    n_lev <- length(x$lev) 
+  }
+
+  col_names <- if (n_lev > 2) colnames(coef(x)) else names(coef(x))
   s <- summary(x)
 
-  coef <- matrix(coef(s),
+  co <- coef(s)
+  coef <- matrix(co,
     byrow = FALSE,
-    nrow = length(x$lev) - 1,
+    nrow = n_lev - 1,
     dimnames = list(
-      x$lev[-1],
+      row.names(co),
       col_names
     )
   )
-  se <- matrix(s$standard.errors,
+
+  se <- s$standard.errors
+  se <- matrix(se,
     byrow = FALSE,
-    nrow = length(x$lev) - 1,
+    nrow = n_lev - 1,
     dimnames = list(
-      x$lev[-1],
+      row.names(se),
       col_names
     )
   )

--- a/tests/testthat/test-nnet.R
+++ b/tests/testthat/test-nnet.R
@@ -10,15 +10,21 @@ library(nnet)
 
 fit <- multinom(gear ~ mpg + factor(am), data = mtcars, trace = FALSE)
 
+response <- t(rmultinom(100, 1, c(0.1, 0.2, 0.3, 0.4)))
+fit_matrix_response <- multinom(response~1, trace = FALSE)
+
 test_that("nnet tidier arguments", {
   check_arguments(tidy.multinom)
   check_arguments(glance.multinom)
 })
 
 test_that("tidy.multinom", {
-  td <- tidy(fit, conf.int = TRUE)
-  check_tidy_output(td)
-  check_dims(td, 6, 8)
+  td1 <- tidy(fit, conf.int = TRUE)
+  td2 <- tidy(fit_matrix_response, conf.int = TRUE)
+  check_tidy_output(td1)
+  check_tidy_output(td2)
+  check_dims(td1, 6, 8)
+  check_dims(td2, 3, 8)
 })
 
 test_that("glance.multinom", {


### PR DESCRIPTION
This PR fixes Issue #666 

The problem was that the `multinom` object does not store a `x$lev` when the response is a matrix.