### PR TITLE
build with deprecated ci.width

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -618,6 +618,8 @@ Suggests:
     zoo
 VignetteBuilder:
     knitr
+Remotes:
+    alexpghayes/modeltests@ci.width
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
PRing for GHA checks. :-)

Related to #984.