### PR TITLE
nnet::multinom bugfix for 2-level y

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 To be released as broom 0.7.5.
 
+* Fixed bug in the `nnet::multinom` tidier in the case that the response
+variable has only two levels (`#993` by `@vincentarelbundock` and `@hughjonesd`)
+
 # broom 0.7.4
 
 broom 0.7.4 introduces tidier support for a number of new model objects and 

--- a/R/nnet-tidiers.R
+++ b/R/nnet-tidiers.R
@@ -42,7 +42,17 @@ tidy.multinom <- function(x, conf.int = FALSE, conf.level = .95,
     n_lev <- length(x$lev) 
   }
 
-  col_names <- if (n_lev > 2) colnames(coef(x)) else names(coef(x))
+  # when the dependent variable has only two levels, there is only one set of
+  # coefficients and coef returns a vector instead of a matrix. row.names is
+  # used to fetch y.level column in tidy output.
+  if (n_lev > 2) {
+    col_names <- colnames(coef(x))
+    row_names <- row.names(coef(x))
+  } else {
+    col_names <- names(coef(x))
+    row_names <- 1
+  }
+
   s <- summary(x)
 
   co <- coef(s)
@@ -50,7 +60,7 @@ tidy.multinom <- function(x, conf.int = FALSE, conf.level = .95,
     byrow = FALSE,
     nrow = n_lev - 1,
     dimnames = list(
-      row.names(co),
+      row_names,
       col_names
     )
   )
@@ -60,7 +70,7 @@ tidy.multinom <- function(x, conf.int = FALSE, conf.level = .95,
     byrow = FALSE,
     nrow = n_lev - 1,
     dimnames = list(
-      row.names(se),
+      row_names,
       col_names
     )
   )

--- a/tests/testthat/test-nnet.R
+++ b/tests/testthat/test-nnet.R
@@ -18,6 +18,15 @@ test_that("nnet tidier arguments", {
   check_arguments(glance.multinom)
 })
 
+test_that("tidy.multinom when y has only 2 levels",{
+  dfr <- data.frame(a = rnorm(100))
+  dfr$y <- dfr$a + rnorm(100)
+  twolevels <- nnet::multinom(I(y > 0) ~ a, dfr, trace = FALSE)
+  td1 <- tidy(twolevels, conf.int = TRUE)
+  check_tidy_output(td1)
+  check_dims(td1, 2, 8)
+})
+
 test_that("tidy.multinom", {
   td1 <- tidy(fit, conf.int = TRUE)
   td2 <- tidy(fit_matrix_response, conf.int = TRUE)


### PR DESCRIPTION
Fix and test for bug reported in this issue: https://github.com/tidymodels/broom/issues/992

The problem was that when `y` has only two levels, `coef(fit)` returns a vector instead of a matrix, so we can't retrieve the row.names, which we use to name fill-in the `y.level` column in `tidy` output.

I decided to still include the `y.level` column here for consistency, and to assign it to "1".