### PR TITLE
Remove special handling of fixest `summary` objects.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -552,7 +552,7 @@ Suggests:
     emmeans,
     epiR,
     ergm (>= 3.10.4),
-    fixest (>= 0.5.0),
+    fixest (>= 0.8.1),
     gam (>= 1.15),
     gamlss,
     gamlss.data,

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ variable has only two levels (`#993` by `@vincentarelbundock` and `@hughjonesd`)
 
 # broom 0.7.4
 
-broom 0.7.4 introduces tidier support for a number of new model objects and
+broom 0.7.4 introduces tidier support for a number of new model objects and 
 improves functionality of many existing tidiers!
 
 #### New Tidiers
@@ -46,8 +46,8 @@ In broom `0.7.0`, we introduced an error for model objects that subclassed
 these objects were supported unintentionally, and we worried that tidiers for
 these objects would silently report innaccurate results.
 
-In hindsight, this change was unnecessarily abrupt. We've decided to roll back
-this change, instead providing the following warning before allowing such
+In hindsight, this change was unnecessarily abrupt. We've decided to roll back 
+this change, instead providing the following warning before allowing such 
 objects to fall back to the `lm`/`glm` tidier methods:
 
 > Tidiers for objects of class {subclass} are not maintained by the broom team, and are only supported through the {dispatched_method} tidier method. Please be cautious in interpreting and reporting broom output."
@@ -64,7 +64,7 @@ In addition,
 
 # broom 0.7.1
 
-While broom 0.7.1 is a minor release, it includes a number of exciting new
+While broom 0.7.1 is a minor release, it includes a number of exciting new 
 features and bug fixes!
 
 #### New tidiers
@@ -75,9 +75,9 @@ features and bug fixes!
 
 #### Improvements to existing tidiers
 
-One of the more major improvements in this release is the addition of the
-`interval` argument to some `augment` methods for confidence, prediction,
-and credible intervals. These columns will be consistently labeled `.lower`
+One of the more major improvements in this release is the addition of the 
+`interval` argument to some `augment` methods for confidence, prediction, 
+and credible intervals. These columns will be consistently labeled `.lower` 
 and `.upper`! (`#908` by `@grantmcdermott`, `#925` by `@bwiernik`)
 
 In addition...
@@ -85,34 +85,34 @@ In addition...
 * Extended the `glance.aov()` method to include an `r.squared` column!
 * `glance.survfit()` now passes `...` to `summary.survfit()` to allow for
 adjustment of RMST and other measures (`#880` by `@vincentarelbundock`)
-* Several unsupported model objects that subclass `glm` and `lm` now error
+* Several unsupported model objects that subclass `glm` and `lm` now error 
 more informatively.
 * A number of improvements to documentation throughout the package.
 
 ####  Bug fixes
 
 * Fixed `newdata` warning message in `augment.*()` output when the `newdata`
-didn't contain the response variable—augment methods no longer expect the
+didn't contain the response variable—augment methods no longer expect the 
 response variable in the supplied `newdata` argument. (`#897` by `@rudeboybert`)
 * Fixed a bug related to `tidy.geeglm()` not being sensitive to the
 `exponentiate` argument (`#867`)
 * Fixed `augment.fixest()` returning residuals in the `.fitted` column. The
-method also now takes a `type.residuals` argument and defaults to the same
+method also now takes a `type.residuals` argument and defaults to the same 
 `type.predict` argument as the `fixest` `predict()` method. (`#877` by `@karldw`)
-* Fix `tidy.felm` confidence interval bug. Replaces "robust" argument with
+* Fix `tidy.felm` confidence interval bug. Replaces "robust" argument with 
 "se.type". (`#919` by `@grantmcdermott`; supersedes `#818` by `@kuriwaki`)
 * Fix a bug in `tidy.drc()` where some term labels would result
 in the overwriting of entries in the `curve` column (`#914`)
 * Fixed bug related to univariate zoo series in `tidy.zoo()` (`#916` by `@WillemVervoort`)
-* Fixed a bug related to `tidy.prcomp()` assigning the wrong PC labels from "loadings"
+* Fixed a bug related to `tidy.prcomp()` assigning the wrong PC labels from "loadings" 
 and "scores" matrices (`#910` by `@tavareshugo`)
 * Fixed `tidy.polr()` bug where p-values could only be returned if
 `exponentiate = FALSE`.
 
 #### Deprecations
 
-We followed through with the planned deprecation of character vector tidiers
-in this release. Other vector tidiers that were soft-deprecated in 0.7.0 will
+We followed through with the planned deprecation of character vector tidiers 
+in this release. Other vector tidiers that were soft-deprecated in 0.7.0 will 
 be fully deprecated in a later release.
 
 # broom 0.7.0
@@ -122,45 +122,45 @@ soft-deprecations, and planned hard-deprecations of functions and arguments.
 
 ### Big picture changes
 
-- We have changed how we report degrees of freedom for `lm` objects
-(#212, #273). This is especially important for instructors in statistics
-courses. Previously the `df` column in `glance.lm()` reported the rank of the
-design matrix. Now it reports degrees of freedom of the numerator for the
-overall F-statistic. This is equal to the rank of the model matrix minus one
-(unless you omit an intercept column), so the new `df` should be the old
+- We have changed how we report degrees of freedom for `lm` objects 
+(#212, #273). This is especially important for instructors in statistics 
+courses. Previously the `df` column in `glance.lm()` reported the rank of the 
+design matrix. Now it reports degrees of freedom of the numerator for the 
+overall F-statistic. This is equal to the rank of the model matrix minus one 
+(unless you omit an intercept column), so the new `df` should be the old 
 `df` minus one.
 
-- We are moving away from supporting `summary.*()` objects. In particular, we
-have removed `tidy.summary.lm()` as part of a major overhaul of internals.
-Instead of calling `tidy()` on `summary`-like objects, please call `tidy()`
+- We are moving away from supporting `summary.*()` objects. In particular, we 
+have removed `tidy.summary.lm()` as part of a major overhaul of internals. 
+Instead of calling `tidy()` on `summary`-like objects, please call `tidy()` 
 directly on model objects moving forward.
 
-- We have removed all support for the `quick` argument in `tidy()` methods.
+- We have removed all support for the `quick` argument in `tidy()` methods. 
 This is to simplify internals and is for maintainability purposes. We anticipate
-this will not influence many users as few people seemed to use it. If this
-majorly cramps your style, let us know, as we are considering a new verb to
-return only model parameters. In the meantime, `stats::coef()` together with
-`tibble::enframe()` provides most of the functionality
+this will not influence many users as few people seemed to use it. If this 
+majorly cramps your style, let us know, as we are considering a new verb to 
+return only model parameters. In the meantime, `stats::coef()` together with 
+`tibble::enframe()` provides most of the functionality 
 of `tidy(..., quick = TRUE)`.
 
-- All `conf.int` arguments now default to `FALSE`, and all `conf.level`
-arguments now default to `0.95`. This should primarily affect `tidy.survreg()`,
-which previously always returned confidence intervals, although there are
+- All `conf.int` arguments now default to `FALSE`, and all `conf.level` 
+arguments now default to `0.95`. This should primarily affect `tidy.survreg()`, 
+which previously always returned confidence intervals, although there are 
 some others.
 
-- Tidiers for `emmeans`-objects use the arguments `conf.int` and `conf.level`
-instead of relying on the argument names native to
-the `emmeans::summary()`-methods (i.e., `infer` and `level`).
-Similarly, `multcomp`-tidiers now include a call to `summary()` as previous
-behavior was akin to setting the now removed argument `quick = TRUE`. Both
-families of tidiers now use the `adj.p.value` column name when appropriate.
-Finally, `emmeans`-, `multcomp`-, and `TukeyHSD`-tidiers now consistently
-use the column names `contrast` and `null.value` instead
+- Tidiers for `emmeans`-objects use the arguments `conf.int` and `conf.level` 
+instead of relying on the argument names native to 
+the `emmeans::summary()`-methods (i.e., `infer` and `level`). 
+Similarly, `multcomp`-tidiers now include a call to `summary()` as previous 
+behavior was akin to setting the now removed argument `quick = TRUE`. Both 
+families of tidiers now use the `adj.p.value` column name when appropriate. 
+Finally, `emmeans`-, `multcomp`-, and `TukeyHSD`-tidiers now consistently 
+use the column names `contrast` and `null.value` instead 
 of `comparison`, `level1` and `level2`, or `lhs` and `rhs` (see #692).
 
 ### Deprecations
 
-This release of `broom` soft-deprecates the following functions and tidier
+This release of `broom` soft-deprecates the following functions and tidier 
 methods:
 
 - Tidier methods for data frames, rowwise data frames, vectors and matrices
@@ -171,10 +171,10 @@ methods:
 - `augment.glmRob()`
 - `tidy.table()` and `tidy.ftable()` have been deprecated in favor of
 `tibble::as_tibble()`
-- `tidy.summaryDefault()` and `glance.summaryDefault()` have been deprecated in
+- `tidy.summaryDefault()` and `glance.summaryDefault()` have been deprecated in 
 favor of `skimr::skim()`
 
-We have also gone forward with our planned mixed model deprecations, and have
+We have also gone forward with our planned mixed model deprecations, and have 
 removed the following methods, which now live in `broom.mixed`:
 
 - `tidy.brmsfit()`
@@ -185,14 +185,14 @@ removed the following methods, which now live in `broom.mixed`:
 
 ### Minor breaking changes
 
-- `augment.factanal()` now returns a tibble with columns names `.fs1`, `.fs2`,
+- `augment.factanal()` now returns a tibble with columns names `.fs1`, `.fs2`, 
   ..., instead of `factor1`, `factor2`, ... (#650)
 
-- We have renamed the output of `augment.htest()`. In particular, we have
+- We have renamed the output of `augment.htest()`. In particular, we have 
   renamed the `.residuals` column to `.resid` and the `.stdres` to `.std.resid`
   for consistency. These changes will only affect chi-squared tests.
 
-- `tidy.ridgelm()` now always return a `GCV` column and never returns an
+- `tidy.ridgelm()` now always return a `GCV` column and never returns an 
   `xm` column. (#533 by @jmuhlenkamp)
 
 - `tidy.dist()` no longer supports the `upper` argument.
@@ -209,17 +209,17 @@ The internals of `augment.*()` methods have largely been overhauled.
 
 - `augment.*()` methods no longer accept an `na.action` argument.
 
-- In previous versions, several `augment.*()` methods inherited the
+- In previous versions, several `augment.*()` methods inherited the 
   `augment.lm()` method, but required additions to the `augment.lm()` method
   itself. We have shifted away from this approach in favor of re-implementing
-  many `augment.*()` methods as standalone methods making use of internal
+  many `augment.*()` methods as standalone methods making use of internal 
   helper functions. As a result, `augment.lm()` and some related methods have
   deprecated (previously unused) arguments.
 
 - `augment()` tries to give an informative error when `data` isn't the original
   training data.
-
-- The `.resid` column in the output of `augment().*` methods is now consistently
+  
+- The `.resid` column in the output of `augment().*` methods is now consistently 
   defined as `y - y_hat`
 
 ## New tidiers
@@ -233,46 +233,46 @@ The internals of `augment.*()` methods have largely been overhauled.
 * `regsubsets` objects from the `leaps` package (#535)
 * `lm.beta` objects from the `lm.beta` package (#545 by @mattle24)
 * `rma` objects from the `metafor` package (#674 by @malcolmbarrett, @softloud)
-* `mfx`, `logitmfx`, `negbinmfx`, `poissonmfx`, `probitmfx`, and `betamfx`
+* `mfx`, `logitmfx`, `negbinmfx`, `poissonmfx`, `probitmfx`, and `betamfx` 
 objects from the`mfx` package (#700 by @grantmcdermott)
 * `lmrob` and `glmrob` objects from the `robustbase` package (#205, #505)
-* `sarlm` objects from the `spatialreg` package (#847 by @gregmacfarlane
+* `sarlm` objects from the `spatialreg` package (#847 by @gregmacfarlane 
 and @petrhrobar)
 * `speedglm` objects from the `speedglm` package (#685)
 * `svyglm` objects from the `survey` package (#611)
 * `systemfit` objects from the `systemfit` package (by @jaspercooper)
 * We have restored a simplified version of `glance.aov()`, which used to inherit
-  from the `glance.lm()` method and now contains only the following columns:
+  from the `glance.lm()` method and now contains only the following columns: 
   `logLik`, `AIC`, `BIC, deviance`, `df.residual`, and `nobs`
-  (see #212). Note that `tidy.aov()` gives more complete information about
+  (see #212). Note that `tidy.aov()` gives more complete information about 
   degrees of freedom in an `aov` object.
 
 ## Improvements to existing tidiers
 
-- `tidy.felm()` now has a `robust = TRUE/FALSE` option that supports robust
+- `tidy.felm()` now has a `robust = TRUE/FALSE` option that supports robust 
   and cluster standard errors. (#781 by @kuriwaki)
 
-- Make `.fitted` values respect `type.predict` argument of `augment.clm()`.
+- Make `.fitted` values respect `type.predict` argument of `augment.clm()`. 
   (#617)
 
-- Return factor rather than numeric class predictions in `.fitted` of
-  `augment.polr()`. (#619) Add an option to return `p.values` in `tidy.polr()`.
+- Return factor rather than numeric class predictions in `.fitted` of 
+  `augment.polr()`. (#619) Add an option to return `p.values` in `tidy.polr()`. 
   (#833 by @LukasWallrich)
 
 - `tidy.kmeans()` now uses the names of the input variables in the output by
   default. Set `col.names = NULL` to recover the old behavior.
 
-- Previously, F-statistics for weak instruments were returned through
-  `glance.ivreg()`. F-statistics are now returned through
+- Previously, F-statistics for weak instruments were returned through 
+  `glance.ivreg()`. F-statistics are now returned through 
   `tidy.ivreg(instruments = TRUE)`. Default is `tidy.ivreg(instruments = FALSE)`.
   `glance.ivreg()` still returns Wu-Hausman and Sargan test statistics.
 
 - `glance.biglm()` now returns a `df.residual` column.
 
-- `tidy.prcomp()` argument `matrix` gained new options `"scores"`,
+- `tidy.prcomp()` argument `matrix` gained new options `"scores"`, 
   `"loadings"`, and `"eigenvalues"`. (#557 by @GegznaV)
 
-- `tidy_optim()` now provides the standard error if the Hessian is present.
+- `tidy_optim()` now provides the standard error if the Hessian is present. 
   (#529 by @billdenney)
 
 - `tidy.htest()` column names are now run through `make.names()` to ensure
@@ -280,10 +280,10 @@ and @petrhrobar)
 
 - `tidy.lmodel2()` now returns a `p.value` column. (#570)
 
-- `tidy.lsmobj()` gained a `conf.int` argument for consistency with other
+- `tidy.lsmobj()` gained a `conf.int` argument for consistency with other 
   tidiers.
 
-- `tidy.polr()` now returns p-values if `p.values` is set to TRUE and the
+- `tidy.polr()` now returns p-values if `p.values` is set to TRUE and the 
   model does not contain factors with more than two levels.
 
 - `tidy.zoo()` now doesn't change column names that have spaces or other
@@ -292,7 +292,7 @@ and @petrhrobar)
 
 - `glance.lavaan()` now uses lavaan extractor functions instead of
   subsetting the fit object manually. (#835)
-
+  
 - `glance.lm()` no longer errors when only an intercept is provided
   as an explanatory variable. (#865)
 
@@ -303,7 +303,7 @@ fitting (#842, #728)
 - Bug fixes in `glance.lavaan()`: address confidence interval error
 (#577) and correct reported `nobs` and `norig` (#835)
 - Bug fix in muhaz tidiers to ensure output is always a `tibble` (#824)
-- Several `glance.*()` methods have been refactored in order to return
+- Several `glance.*()` methods have been refactored in order to return 
 a one-row tibble even when the model matrix is rank-deficient (#823)
 - Bug fix to return confidence intervals correct in `tidy.drc()` (#798)
 - Added default methods for objects that subclass `glm` and `lm` in order to
@@ -316,13 +316,13 @@ error more informatively. (#749, #736, #708, #186)
 
 ### Other changes
 
-- Many `glance()` methods now return a `nobs` column, which contains the
+- Many `glance()` methods now return a `nobs` column, which contains the 
 number of data points used to fit the model! (#597 by @vincentarelbundock)
 
 - `tidy()` no longer checks for a log or logit link when `exponentiate = TRUE`,
-and we have refactored to remove extraneous `exponentiate` arguments. If you
-set `exponentiate = TRUE`, we assume you know what you are doing and that you
-want exponentiated coefficients (and confidence intervals if `conf.int = TRUE`)
+and we have refactored to remove extraneous `exponentiate` arguments. If you 
+set `exponentiate = TRUE`, we assume you know what you are doing and that you 
+want exponentiated coefficients (and confidence intervals if `conf.int = TRUE`) 
 regardless of link function.
 
 - We now use `rlang::arg_match()` when possible instead of `arg.match()` to give
@@ -338,7 +338,7 @@ regardless of link function.
 
 - Various warnings resulting from changes to the tidyr API in v1.0.0 have
   been fixed. (#870)
-
+  
 - Removed dependencies on reshape2 and superseded functions in dplyr.
 
 - All documentation now links to help files rather than topics.
@@ -346,22 +346,22 @@ regardless of link function.
 ## For developers and contributors
 
 - Moved core tests to the `modeltests` package.
-
+  
 - Generally, after this release, the broom dev team will first ask that
   attempts to add tidier methods supporting a model object are first
-  directed to the model-owning package. An article describing best practices
-  in doing so can be found on the {tidymodels} website at
+  directed to the model-owning package. An article describing best practices 
+  in doing so can be found on the {tidymodels} website at 
   https://www.tidymodels.org/learn/develop/broom/, and we will continue
   adding additional resources to that article as we develop them. In the case
   that the maintainer is uninterested in taking on the tidier methods, please
   note this in your issue or PR.
 
-- Added a new vignette discussing how to implement new tidier methods in
+- Added a new vignette discussing how to implement new tidier methods in 
   non-broom packages.
 
 # broom 0.5.6
 
-- Fix failing CRAN checks to due `tibble 3.0.0` release. Removed
+- Fix failing CRAN checks to due `tibble 3.0.0` release. Removed 
 `xergm` dependency.
 
 # broom 0.5.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ To be released as broom 0.7.6.
 * Fixed bug in `augment` tidiers resulting in `.fitted` and `.se.fit` array columns.
 * Fixed bug that made column `y` non-numeric after `tidy_xyz` (`#973` by `@jiho`)
 * Add tidiers for `MASS:glm.nb` (`#998` by `@joshyam-k`)
+* Fixed bug in `tidy.fixest` that sometimes prevented arguments like `se` from being used (`#1001` by `@karldw`)
 
 # broom 0.7.5
 
@@ -14,7 +15,7 @@ variable has only two levels (`#993` by `@vincentarelbundock` and `@hughjonesd`)
 
 # broom 0.7.4
 
-broom 0.7.4 introduces tidier support for a number of new model objects and 
+broom 0.7.4 introduces tidier support for a number of new model objects and
 improves functionality of many existing tidiers!
 
 #### New Tidiers
@@ -45,8 +46,8 @@ In broom `0.7.0`, we introduced an error for model objects that subclassed
 these objects were supported unintentionally, and we worried that tidiers for
 these objects would silently report innaccurate results.
 
-In hindsight, this change was unnecessarily abrupt. We've decided to roll back 
-this change, instead providing the following warning before allowing such 
+In hindsight, this change was unnecessarily abrupt. We've decided to roll back
+this change, instead providing the following warning before allowing such
 objects to fall back to the `lm`/`glm` tidier methods:
 
 > Tidiers for objects of class {subclass} are not maintained by the broom team, and are only supported through the {dispatched_method} tidier method. Please be cautious in interpreting and reporting broom output."
@@ -63,7 +64,7 @@ In addition,
 
 # broom 0.7.1
 
-While broom 0.7.1 is a minor release, it includes a number of exciting new 
+While broom 0.7.1 is a minor release, it includes a number of exciting new
 features and bug fixes!
 
 #### New tidiers
@@ -74,9 +75,9 @@ features and bug fixes!
 
 #### Improvements to existing tidiers
 
-One of the more major improvements in this release is the addition of the 
-`interval` argument to some `augment` methods for confidence, prediction, 
-and credible intervals. These columns will be consistently labeled `.lower` 
+One of the more major improvements in this release is the addition of the
+`interval` argument to some `augment` methods for confidence, prediction,
+and credible intervals. These columns will be consistently labeled `.lower`
 and `.upper`! (`#908` by `@grantmcdermott`, `#925` by `@bwiernik`)
 
 In addition...
@@ -84,34 +85,34 @@ In addition...
 * Extended the `glance.aov()` method to include an `r.squared` column!
 * `glance.survfit()` now passes `...` to `summary.survfit()` to allow for
 adjustment of RMST and other measures (`#880` by `@vincentarelbundock`)
-* Several unsupported model objects that subclass `glm` and `lm` now error 
+* Several unsupported model objects that subclass `glm` and `lm` now error
 more informatively.
 * A number of improvements to documentation throughout the package.
 
 ####  Bug fixes
 
 * Fixed `newdata` warning message in `augment.*()` output when the `newdata`
-didn't contain the response variable—augment methods no longer expect the 
+didn't contain the response variable—augment methods no longer expect the
 response variable in the supplied `newdata` argument. (`#897` by `@rudeboybert`)
 * Fixed a bug related to `tidy.geeglm()` not being sensitive to the
 `exponentiate` argument (`#867`)
 * Fixed `augment.fixest()` returning residuals in the `.fitted` column. The
-method also now takes a `type.residuals` argument and defaults to the same 
+method also now takes a `type.residuals` argument and defaults to the same
 `type.predict` argument as the `fixest` `predict()` method. (`#877` by `@karldw`)
-* Fix `tidy.felm` confidence interval bug. Replaces "robust" argument with 
+* Fix `tidy.felm` confidence interval bug. Replaces "robust" argument with
 "se.type". (`#919` by `@grantmcdermott`; supersedes `#818` by `@kuriwaki`)
 * Fix a bug in `tidy.drc()` where some term labels would result
 in the overwriting of entries in the `curve` column (`#914`)
 * Fixed bug related to univariate zoo series in `tidy.zoo()` (`#916` by `@WillemVervoort`)
-* Fixed a bug related to `tidy.prcomp()` assigning the wrong PC labels from "loadings" 
+* Fixed a bug related to `tidy.prcomp()` assigning the wrong PC labels from "loadings"
 and "scores" matrices (`#910` by `@tavareshugo`)
 * Fixed `tidy.polr()` bug where p-values could only be returned if
 `exponentiate = FALSE`.
 
 #### Deprecations
 
-We followed through with the planned deprecation of character vector tidiers 
-in this release. Other vector tidiers that were soft-deprecated in 0.7.0 will 
+We followed through with the planned deprecation of character vector tidiers
+in this release. Other vector tidiers that were soft-deprecated in 0.7.0 will
 be fully deprecated in a later release.
 
 # broom 0.7.0
@@ -121,45 +122,45 @@ soft-deprecations, and planned hard-deprecations of functions and arguments.
 
 ### Big picture changes
 
-- We have changed how we report degrees of freedom for `lm` objects 
-(#212, #273). This is especially important for instructors in statistics 
-courses. Previously the `df` column in `glance.lm()` reported the rank of the 
-design matrix. Now it reports degrees of freedom of the numerator for the 
-overall F-statistic. This is equal to the rank of the model matrix minus one 
-(unless you omit an intercept column), so the new `df` should be the old 
+- We have changed how we report degrees of freedom for `lm` objects
+(#212, #273). This is especially important for instructors in statistics
+courses. Previously the `df` column in `glance.lm()` reported the rank of the
+design matrix. Now it reports degrees of freedom of the numerator for the
+overall F-statistic. This is equal to the rank of the model matrix minus one
+(unless you omit an intercept column), so the new `df` should be the old
 `df` minus one.
 
-- We are moving away from supporting `summary.*()` objects. In particular, we 
-have removed `tidy.summary.lm()` as part of a major overhaul of internals. 
-Instead of calling `tidy()` on `summary`-like objects, please call `tidy()` 
+- We are moving away from supporting `summary.*()` objects. In particular, we
+have removed `tidy.summary.lm()` as part of a major overhaul of internals.
+Instead of calling `tidy()` on `summary`-like objects, please call `tidy()`
 directly on model objects moving forward.
 
-- We have removed all support for the `quick` argument in `tidy()` methods. 
+- We have removed all support for the `quick` argument in `tidy()` methods.
 This is to simplify internals and is for maintainability purposes. We anticipate
-this will not influence many users as few people seemed to use it. If this 
-majorly cramps your style, let us know, as we are considering a new verb to 
-return only model parameters. In the meantime, `stats::coef()` together with 
-`tibble::enframe()` provides most of the functionality 
+this will not influence many users as few people seemed to use it. If this
+majorly cramps your style, let us know, as we are considering a new verb to
+return only model parameters. In the meantime, `stats::coef()` together with
+`tibble::enframe()` provides most of the functionality
 of `tidy(..., quick = TRUE)`.
 
-- All `conf.int` arguments now default to `FALSE`, and all `conf.level` 
-arguments now default to `0.95`. This should primarily affect `tidy.survreg()`, 
-which previously always returned confidence intervals, although there are 
+- All `conf.int` arguments now default to `FALSE`, and all `conf.level`
+arguments now default to `0.95`. This should primarily affect `tidy.survreg()`,
+which previously always returned confidence intervals, although there are
 some others.
 
-- Tidiers for `emmeans`-objects use the arguments `conf.int` and `conf.level` 
-instead of relying on the argument names native to 
-the `emmeans::summary()`-methods (i.e., `infer` and `level`). 
-Similarly, `multcomp`-tidiers now include a call to `summary()` as previous 
-behavior was akin to setting the now removed argument `quick = TRUE`. Both 
-families of tidiers now use the `adj.p.value` column name when appropriate. 
-Finally, `emmeans`-, `multcomp`-, and `TukeyHSD`-tidiers now consistently 
-use the column names `contrast` and `null.value` instead 
+- Tidiers for `emmeans`-objects use the arguments `conf.int` and `conf.level`
+instead of relying on the argument names native to
+the `emmeans::summary()`-methods (i.e., `infer` and `level`).
+Similarly, `multcomp`-tidiers now include a call to `summary()` as previous
+behavior was akin to setting the now removed argument `quick = TRUE`. Both
+families of tidiers now use the `adj.p.value` column name when appropriate.
+Finally, `emmeans`-, `multcomp`-, and `TukeyHSD`-tidiers now consistently
+use the column names `contrast` and `null.value` instead
 of `comparison`, `level1` and `level2`, or `lhs` and `rhs` (see #692).
 
 ### Deprecations
 
-This release of `broom` soft-deprecates the following functions and tidier 
+This release of `broom` soft-deprecates the following functions and tidier
 methods:
 
 - Tidier methods for data frames, rowwise data frames, vectors and matrices
@@ -170,10 +171,10 @@ methods:
 - `augment.glmRob()`
 - `tidy.table()` and `tidy.ftable()` have been deprecated in favor of
 `tibble::as_tibble()`
-- `tidy.summaryDefault()` and `glance.summaryDefault()` have been deprecated in 
+- `tidy.summaryDefault()` and `glance.summaryDefault()` have been deprecated in
 favor of `skimr::skim()`
 
-We have also gone forward with our planned mixed model deprecations, and have 
+We have also gone forward with our planned mixed model deprecations, and have
 removed the following methods, which now live in `broom.mixed`:
 
 - `tidy.brmsfit()`
@@ -184,14 +185,14 @@ removed the following methods, which now live in `broom.mixed`:
 
 ### Minor breaking changes
 
-- `augment.factanal()` now returns a tibble with columns names `.fs1`, `.fs2`, 
+- `augment.factanal()` now returns a tibble with columns names `.fs1`, `.fs2`,
   ..., instead of `factor1`, `factor2`, ... (#650)
 
-- We have renamed the output of `augment.htest()`. In particular, we have 
+- We have renamed the output of `augment.htest()`. In particular, we have
   renamed the `.residuals` column to `.resid` and the `.stdres` to `.std.resid`
   for consistency. These changes will only affect chi-squared tests.
 
-- `tidy.ridgelm()` now always return a `GCV` column and never returns an 
+- `tidy.ridgelm()` now always return a `GCV` column and never returns an
   `xm` column. (#533 by @jmuhlenkamp)
 
 - `tidy.dist()` no longer supports the `upper` argument.
@@ -208,17 +209,17 @@ The internals of `augment.*()` methods have largely been overhauled.
 
 - `augment.*()` methods no longer accept an `na.action` argument.
 
-- In previous versions, several `augment.*()` methods inherited the 
+- In previous versions, several `augment.*()` methods inherited the
   `augment.lm()` method, but required additions to the `augment.lm()` method
   itself. We have shifted away from this approach in favor of re-implementing
-  many `augment.*()` methods as standalone methods making use of internal 
+  many `augment.*()` methods as standalone methods making use of internal
   helper functions. As a result, `augment.lm()` and some related methods have
   deprecated (previously unused) arguments.
 
 - `augment()` tries to give an informative error when `data` isn't the original
   training data.
-  
-- The `.resid` column in the output of `augment().*` methods is now consistently 
+
+- The `.resid` column in the output of `augment().*` methods is now consistently
   defined as `y - y_hat`
 
 ## New tidiers
@@ -232,46 +233,46 @@ The internals of `augment.*()` methods have largely been overhauled.
 * `regsubsets` objects from the `leaps` package (#535)
 * `lm.beta` objects from the `lm.beta` package (#545 by @mattle24)
 * `rma` objects from the `metafor` package (#674 by @malcolmbarrett, @softloud)
-* `mfx`, `logitmfx`, `negbinmfx`, `poissonmfx`, `probitmfx`, and `betamfx` 
+* `mfx`, `logitmfx`, `negbinmfx`, `poissonmfx`, `probitmfx`, and `betamfx`
 objects from the`mfx` package (#700 by @grantmcdermott)
 * `lmrob` and `glmrob` objects from the `robustbase` package (#205, #505)
-* `sarlm` objects from the `spatialreg` package (#847 by @gregmacfarlane 
+* `sarlm` objects from the `spatialreg` package (#847 by @gregmacfarlane
 and @petrhrobar)
 * `speedglm` objects from the `speedglm` package (#685)
 * `svyglm` objects from the `survey` package (#611)
 * `systemfit` objects from the `systemfit` package (by @jaspercooper)
 * We have restored a simplified version of `glance.aov()`, which used to inherit
-  from the `glance.lm()` method and now contains only the following columns: 
+  from the `glance.lm()` method and now contains only the following columns:
   `logLik`, `AIC`, `BIC, deviance`, `df.residual`, and `nobs`
-  (see #212). Note that `tidy.aov()` gives more complete information about 
+  (see #212). Note that `tidy.aov()` gives more complete information about
   degrees of freedom in an `aov` object.
 
 ## Improvements to existing tidiers
 
-- `tidy.felm()` now has a `robust = TRUE/FALSE` option that supports robust 
+- `tidy.felm()` now has a `robust = TRUE/FALSE` option that supports robust
   and cluster standard errors. (#781 by @kuriwaki)
 
-- Make `.fitted` values respect `type.predict` argument of `augment.clm()`. 
+- Make `.fitted` values respect `type.predict` argument of `augment.clm()`.
   (#617)
 
-- Return factor rather than numeric class predictions in `.fitted` of 
-  `augment.polr()`. (#619) Add an option to return `p.values` in `tidy.polr()`. 
+- Return factor rather than numeric class predictions in `.fitted` of
+  `augment.polr()`. (#619) Add an option to return `p.values` in `tidy.polr()`.
   (#833 by @LukasWallrich)
 
 - `tidy.kmeans()` now uses the names of the input variables in the output by
   default. Set `col.names = NULL` to recover the old behavior.
 
-- Previously, F-statistics for weak instruments were returned through 
-  `glance.ivreg()`. F-statistics are now returned through 
+- Previously, F-statistics for weak instruments were returned through
+  `glance.ivreg()`. F-statistics are now returned through
   `tidy.ivreg(instruments = TRUE)`. Default is `tidy.ivreg(instruments = FALSE)`.
   `glance.ivreg()` still returns Wu-Hausman and Sargan test statistics.
 
 - `glance.biglm()` now returns a `df.residual` column.
 
-- `tidy.prcomp()` argument `matrix` gained new options `"scores"`, 
+- `tidy.prcomp()` argument `matrix` gained new options `"scores"`,
   `"loadings"`, and `"eigenvalues"`. (#557 by @GegznaV)
 
-- `tidy_optim()` now provides the standard error if the Hessian is present. 
+- `tidy_optim()` now provides the standard error if the Hessian is present.
   (#529 by @billdenney)
 
 - `tidy.htest()` column names are now run through `make.names()` to ensure
@@ -279,10 +280,10 @@ and @petrhrobar)
 
 - `tidy.lmodel2()` now returns a `p.value` column. (#570)
 
-- `tidy.lsmobj()` gained a `conf.int` argument for consistency with other 
+- `tidy.lsmobj()` gained a `conf.int` argument for consistency with other
   tidiers.
 
-- `tidy.polr()` now returns p-values if `p.values` is set to TRUE and the 
+- `tidy.polr()` now returns p-values if `p.values` is set to TRUE and the
   model does not contain factors with more than two levels.
 
 - `tidy.zoo()` now doesn't change column names that have spaces or other
@@ -291,7 +292,7 @@ and @petrhrobar)
 
 - `glance.lavaan()` now uses lavaan extractor functions instead of
   subsetting the fit object manually. (#835)
-  
+
 - `glance.lm()` no longer errors when only an intercept is provided
   as an explanatory variable. (#865)
 
@@ -302,7 +303,7 @@ fitting (#842, #728)
 - Bug fixes in `glance.lavaan()`: address confidence interval error
 (#577) and correct reported `nobs` and `norig` (#835)
 - Bug fix in muhaz tidiers to ensure output is always a `tibble` (#824)
-- Several `glance.*()` methods have been refactored in order to return 
+- Several `glance.*()` methods have been refactored in order to return
 a one-row tibble even when the model matrix is rank-deficient (#823)
 - Bug fix to return confidence intervals correct in `tidy.drc()` (#798)
 - Added default methods for objects that subclass `glm` and `lm` in order to
@@ -315,13 +316,13 @@ error more informatively. (#749, #736, #708, #186)
 
 ### Other changes
 
-- Many `glance()` methods now return a `nobs` column, which contains the 
+- Many `glance()` methods now return a `nobs` column, which contains the
 number of data points used to fit the model! (#597 by @vincentarelbundock)
 
 - `tidy()` no longer checks for a log or logit link when `exponentiate = TRUE`,
-and we have refactored to remove extraneous `exponentiate` arguments. If you 
-set `exponentiate = TRUE`, we assume you know what you are doing and that you 
-want exponentiated coefficients (and confidence intervals if `conf.int = TRUE`) 
+and we have refactored to remove extraneous `exponentiate` arguments. If you
+set `exponentiate = TRUE`, we assume you know what you are doing and that you
+want exponentiated coefficients (and confidence intervals if `conf.int = TRUE`)
 regardless of link function.
 
 - We now use `rlang::arg_match()` when possible instead of `arg.match()` to give
@@ -337,7 +338,7 @@ regardless of link function.
 
 - Various warnings resulting from changes to the tidyr API in v1.0.0 have
   been fixed. (#870)
-  
+
 - Removed dependencies on reshape2 and superseded functions in dplyr.
 
 - All documentation now links to help files rather than topics.
@@ -345,22 +346,22 @@ regardless of link function.
 ## For developers and contributors
 
 - Moved core tests to the `modeltests` package.
-  
+
 - Generally, after this release, the broom dev team will first ask that
   attempts to add tidier methods supporting a model object are first
-  directed to the model-owning package. An article describing best practices 
-  in doing so can be found on the {tidymodels} website at 
+  directed to the model-owning package. An article describing best practices
+  in doing so can be found on the {tidymodels} website at
   https://www.tidymodels.org/learn/develop/broom/, and we will continue
   adding additional resources to that article as we develop them. In the case
   that the maintainer is uninterested in taking on the tidier methods, please
   note this in your issue or PR.
 
-- Added a new vignette discussing how to implement new tidier methods in 
+- Added a new vignette discussing how to implement new tidier methods in
   non-broom packages.
 
 # broom 0.5.6
 
-- Fix failing CRAN checks to due `tibble 3.0.0` release. Removed 
+- Fix failing CRAN checks to due `tibble 3.0.0` release. Removed
 `xergm` dependency.
 
 # broom 0.5.5


### PR DESCRIPTION
fixest, since v0.8.1, remembers the settings passed to `summary`, so `tidy.fixest` can call `summary` again without losing any settings that were passed in the first `summary` call. That means we don't have to handle pre-summarized objects differently.

Fixes #1001 (see reprex in that issue).
