### PR TITLE
Added `tidy.negbin(exponentiate=)` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: broom
 Title: Convert Statistical Objects into Tidy Tibbles
-Version: 0.7.6
+Version: 0.7.6.9000
 Authors@R:
     c(person(given = "David",
              family = "Robinson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# broom (development version)
+
+* Added `exponentiate` argument to `tidy.negbin()` tidier. (`#1011` by `@ddsjoberg`)
+
 # broom 0.7.6
 
 * Fixed bug in `augment` tidiers resulting in `.fitted` and `.se.fit` array columns.

--- a/R/mass-negbin-tidiers.R
+++ b/R/mass-negbin-tidiers.R
@@ -48,6 +48,7 @@ glance.negbin <- function(x, ...) {
 
 #' @templateVar class negbin
 #' @template title_desc_tidy
+#' @template param_exponentiate
 #'
 #' @inherit glance.negbin examples
 #'
@@ -58,7 +59,8 @@ glance.negbin <- function(x, ...) {
 #' @family glm.nb tidiers
 #' @seealso [MASS::glm.nb()]
 #' @export
- tidy.negbin <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
+ tidy.negbin <- function(x, conf.int = FALSE, conf.level = 0.95, 
+                        exponentiate = FALSE, ...) {
   s <- summary(x, ...)
   
   ret <- tibble(
@@ -72,6 +74,10 @@ glance.negbin <- function(x, ...) {
   if (conf.int) {
     ci <- broom_confint_terms(x, level = conf.level)
     ret <- dplyr::left_join(ret, ci, by = "term")
+  }
+  
+  if (exponentiate) {
+    ret <- exponentiate(ret)
   }
   
   ret

--- a/man/tidy.negbin.Rd
+++ b/man/tidy.negbin.Rd
@@ -4,7 +4,7 @@
 \alias{tidy.negbin}
 \title{Tidy a(n) negbin object}
 \usage{
-\method{tidy}{negbin}(x, conf.int = FALSE, conf.level = 0.95, ...)
+\method{tidy}{negbin}(x, conf.int = FALSE, conf.level = 0.95, exponentiate = FALSE, ...)
 }
 \arguments{
 \item{x}{A \code{glm.nb} object returned by \code{\link[MASS:glm.nb]{MASS::glm.nb()}}.}
@@ -15,6 +15,11 @@ interval in the tidied output. Defaults to \code{FALSE}.}
 \item{conf.level}{The confidence level to use for the confidence interval
 if \code{conf.int = TRUE}. Must be strictly greater than 0 and less than 1.
 Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
+
+\item{exponentiate}{Logical indicating whether or not to exponentiate the
+the coefficient estimates. This is typical for logistic and multinomial
+regressions, but a bad idea if there is no log or logit link. Defaults
+to \code{FALSE}.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be

--- a/tests/testthat/test-mass-negbin.R
+++ b/tests/testthat/test-mass-negbin.R
@@ -31,3 +31,13 @@ test_that("glance.negbin", {
 })
 
 
+test_that("tidy.negbin exponentiate arg", {
+  td3 <- tidy(fit, exponentiate = TRUE, conf.int = TRUE)
+  td4 <- tidy(fit, exponentiate = FALSE, conf.int = TRUE)
+  expect_equal(
+    as.matrix(td3[, c("estimate", "conf.low", "conf.high")]),
+    exp(as.matrix(td4[, c("estimate", "conf.low", "conf.high")]))
+  )
+})
+  
+

--- a/tests/testthat/test-mass-negbin.R
+++ b/tests/testthat/test-mass-negbin.R
@@ -16,12 +16,19 @@ test_that("MASS::glm.nb tidier arguments", {
 test_that("tidy.negbin", {
   td1 <- tidy(fit)
   td2 <- tidy(fit, conf.int = TRUE)
+  td3 <- tidy(fit, exponentiate = TRUE, conf.int = TRUE)
   
   check_tidy_output(td2)
   check_tidy_output(td1)
   
   expect_false(NA %in% td2$conf.low)
   expect_false(NA %in% td2$conf.high)
+  
+  # exponentiate arg check
+  expect_equal(
+    as.matrix(td3[, c("estimate", "conf.low", "conf.high")]),
+    exp(as.matrix(td2[, c("estimate", "conf.low", "conf.high")]))
+  )
 })
 
 test_that("glance.negbin", {
@@ -29,15 +36,3 @@ test_that("glance.negbin", {
   check_glance_outputs(gl)
   check_dims(gl, 1, 8)
 })
-
-
-test_that("tidy.negbin exponentiate arg", {
-  td3 <- tidy(fit, exponentiate = TRUE, conf.int = TRUE)
-  td4 <- tidy(fit, exponentiate = FALSE, conf.int = TRUE)
-  expect_equal(
-    as.matrix(td3[, c("estimate", "conf.low", "conf.high")]),
-    exp(as.matrix(td4[, c("estimate", "conf.low", "conf.high")]))
-  )
-})
-  
-


### PR DESCRIPTION
Hello!

Here's a small PR to add the `exponentiate=` argument to the `tidy.negbin()` tidier. 
- I've added documentation for the new argument using the template I've seen in other tidier roxygen comments
- I've added a test to assure the coefs are indeed exponentiated.
- `NEWS.md` has been updated
- I did not add myself as a contributor....this addition is _quite_ minor!

closes #1011
