### PR TITLE
Adds the `exponentiate=` argument to `tidy.gam()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: broom
 Title: Convert Statistical Objects into Tidy Tibbles
-Version: 0.7.6.9000
+Version: 0.7.6.9001
 Authors@R:
     c(person(given = "David",
              family = "Robinson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # broom (development version)
 
+* Added `exponentiate` argument to `tidy.gam()` tidier applicable for parametric terms. (`#1013` by `@ddsjoberg`)
 * Added `exponentiate` argument to `tidy.negbin()` tidier. (`#1011` by `@ddsjoberg`)
 
 # broom 0.7.6

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -6,6 +6,7 @@
 #'   be tidied. Defaults to `FALSE`, meaning that smooth terms are tidied
 #'   by default.
 #' @template param_confint
+#' @template param_exponentiate
 #' @template param_unused_dots
 #'
 #' @evalRd return_tidy(
@@ -37,9 +38,12 @@
 #' @family mgcv tidiers
 #' @seealso [tidy()], [mgcv::gam()]
 tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE,
-                     conf.level = 0.95, ...) {
+                     conf.level = 0.95, exponentiate = FALSE, ...) {
   if (!parametric && conf.int) {
     message("Confidence intervals only available for parametric terms.")
+  }
+  if (!parametric && exponentiate) {
+    message("Exponentiating coefficients only available for parametric terms.")
   }
   if (parametric) {
     px <- summary(x)$p.table
@@ -64,6 +68,11 @@ tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE,
     class(sx) <- c("anova", "data.frame")
     ret <- tidy(sx)
   }
+  
+  if (exponentiate && parametric) {
+    ret <- exponentiate(ret)  
+  }
+  
   ret
 }
 

--- a/man/tidy.gam.Rd
+++ b/man/tidy.gam.Rd
@@ -6,7 +6,14 @@
 \alias{gam_tidiers}
 \title{Tidy a(n) gam object}
 \usage{
-\method{tidy}{gam}(x, parametric = FALSE, conf.int = FALSE, conf.level = 0.95, ...)
+\method{tidy}{gam}(
+  x,
+  parametric = FALSE,
+  conf.int = FALSE,
+  conf.level = 0.95,
+  exponentiate = FALSE,
+  ...
+)
 }
 \arguments{
 \item{x}{A \code{gam} object returned from a call to \code{\link[mgcv:gam]{mgcv::gam()}}.}
@@ -21,6 +28,11 @@ interval in the tidied output. Defaults to \code{FALSE}.}
 \item{conf.level}{The confidence level to use for the confidence interval
 if \code{conf.int = TRUE}. Must be strictly greater than 0 and less than 1.
 Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
+
+\item{exponentiate}{Logical indicating whether or not to exponentiate the
+the coefficient estimates. This is typical for logistic and multinomial
+regressions, but a bad idea if there is no log or logit link. Defaults
+to \code{FALSE}.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be

--- a/tests/testthat/test-mgcv.R
+++ b/tests/testthat/test-mgcv.R
@@ -17,8 +17,8 @@ test_that("mgcv tidier arguments", {
 
 test_that("tidy.gam", {
   td <- tidy(fit)
-  tdp <- tidy(fit, parametric = TRUE)
-  tdp_exp <- tidy(fit, parametric = TRUE, exponentiate = TRUE)
+  tdp <- tidy(fit, parametric = TRUE, conf.int = TRUE)
+  tdp_exp <- tidy(fit, parametric = TRUE, conf.int = TRUE, exponentiate = TRUE)
 
   check_tidy_output(td, strict = FALSE)
   check_tidy_output(tdp)

--- a/tests/testthat/test-mgcv.R
+++ b/tests/testthat/test-mgcv.R
@@ -18,9 +18,16 @@ test_that("mgcv tidier arguments", {
 test_that("tidy.gam", {
   td <- tidy(fit)
   tdp <- tidy(fit, parametric = TRUE)
+  tdp_exp <- tidy(fit, parametric = TRUE, exponentiate = TRUE)
 
   check_tidy_output(td, strict = FALSE)
   check_tidy_output(tdp)
+  
+  # test coef exponentiated 
+  expect_equal(
+    tdp_exp$estimate,
+    exp(tdp$estimate)
+  )
 })
 
 test_that("glance.gam", {

--- a/tests/testthat/test-mgcv.R
+++ b/tests/testthat/test-mgcv.R
@@ -25,8 +25,8 @@ test_that("tidy.gam", {
   
   # test coef exponentiated 
   expect_equal(
-    tdp_exp$estimate,
-    exp(tdp$estimate)
+    as.matrix(tdp_exp[,c("estimate", "conf.low", "conf.high")]),
+    exp(as.matrix(tdp[,c("estimate", "conf.low", "conf.high")]))
   )
 })
 


### PR DESCRIPTION
PR adds the `exponentiate=` argument to `tidy.gam()`. 

- The argument only applies when `parametric = TRUE` (similar to `conf.int=`). 
- If user requests exponentiated coefs when `parametric = FALSE`, they are notified the argument has been ignored (just like what happens with  `conf.int=`).

