### PR TITLE
Fix issue with lfe having many outcome and conf.int=TRUE, fixes #1019

### DIFF
--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -112,12 +112,14 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, se.type
   if (conf.int) {
     if (has_multi_response) {
       ci <- map_df(x$lhs, function(y) {
-        broom_confint_terms(x, level = conf.level, type = NULL, lhs = y)
+        broom_confint_terms(x, level = conf.level, type = NULL, lhs = y) %>% 
+          mutate(response=y)
       })
+      ret <- dplyr::left_join(ret, ci, by = c("response", "term"))
     } else {
       ci <- broom_confint_terms(x, level = conf.level, type = se.type)
+      ret <- dplyr::left_join(ret, ci, by = "term")
     }
-    ret <- dplyr::left_join(ret, ci, by = "term")
   }
   
   if (fe) {

--- a/tests/testthat/test-lfe.R
+++ b/tests/testthat/test-lfe.R
@@ -24,7 +24,10 @@ fit2 <- lfe::felm(v2 ~ v3 | id + v1, df, na.action = na.exclude)
 
 # with clus
 fit3 <- lfe::felm(v2 ~ v3 | 0 | 0 | id + v1, df, na.action = na.exclude)
+
+## with multiple outcomes
 fit_multi <- lfe::felm(v1 + v2 ~ v3 , df)
+fit_Y2 <- lfe::felm(v1 ~ v3 , df)
 
 form <- v2 ~ v4
 fit_form <- lfe::felm(form, df) # part of a regression test
@@ -48,6 +51,7 @@ test_that("tidy.felm", {
   
   
   td_multi <- tidy(fit_multi)
+  td_multi_CI <- tidy(fit_multi, conf.int = TRUE)
   
   check_tidy_output(td1)
   check_tidy_output(td2)
@@ -59,10 +63,18 @@ test_that("tidy.felm", {
   check_tidy_output(td8)
   check_tidy_output(td9)
   check_tidy_output(td_multi)
+  check_tidy_output(td_multi_CI)
   
   check_dims(td1, 2, 5)
+  check_dims(td_multi_CI, 4, 8)
   
-  expect_equal(tidy(fit_multi)[3:4, -1], tidy(fit))
+  expect_equal(tidy(fit_multi)[3:4, -1],
+               tidy(fit))
+  expect_equal(tidy(fit_multi, conf.int = TRUE)[3:4, -1],
+               tidy(fit, conf.int = TRUE))
+  expect_equal(tidy(fit_multi, conf.int = TRUE)[1:2, -1],
+               tidy(fit_Y2, conf.int = TRUE))
+  
   expect_equal(dplyr::pull(td5, std.error),
                as.numeric(lfe:::summary.felm(fit, robust = TRUE)$coef[, "Robust s.e"]))
   expect_equal(dplyr::pull(td6, std.error),


### PR DESCRIPTION
This fixes issue https://github.com/tidymodels/broom/issues/1019

``` r
library(lfe)
#> Loading required package: Matrix
library(plm)
#> 
#> Attaching package: 'plm'
#> The following object is masked from 'package:lfe':
#> 
#>     sargan
data(Produc)

packageVersion("broom")
#> [1] '0.7.6.9001'
broom::tidy(x=felm(pcap+util~hwy|state|0|state, data=Produc))
#> # A tibble: 2 x 6
#>   response term  estimate std.error statistic  p.value
#>   <chr>    <chr>    <dbl>     <dbl>     <dbl>    <dbl>
#> 1 pcap     hwy       3.05     0.365      8.35 7.80e-11
#> 2 util     hwy       1.52     0.697      2.18 3.39e- 2

broom::tidy(x=felm(pcap+util~hwy|state|0|state, data=Produc), conf.int=TRUE)
#> # A tibble: 2 x 8
#>   response term  estimate std.error statistic  p.value conf.low conf.high
#>   <chr>    <chr>    <dbl>     <dbl>     <dbl>    <dbl>    <dbl>     <dbl>
#> 1 pcap     hwy       3.05     0.365      8.35 7.80e-11    2.32       3.79
#> 2 util     hwy       1.52     0.697      2.18 3.39e- 2    0.121      2.92
```

<sup>Created on 2021-05-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
