### PR TITLE
Fixes error in tidy.epi.2by2 caused by new version of epiR (#1028)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,13 +5,13 @@
 
 # broom 0.7.6
 
-* Fixed bug in `tidy.epi.2by2` that resulted in errors with new version of `epiR` (`#1028` by `@nt-williams`)
 * Fixed bug in `augment` tidiers resulting in `.fitted` and `.se.fit` array columns.
 * Fixed bug that made column `y` non-numeric after `tidy_xyz` (`#973` by `@jiho`)
 * Added tidiers for `MASS:glm.nb` (`#998` by `@joshyam-k`)
 * Fixed bug in `tidy.fixest` that sometimes prevented arguments like `se` from being used (`#1001` by `@karldw`)
 * Fixed bug in `tidy.fixest` that resulted in errors when columns with name
 `x` are present (`#1007` by `@grantmcdermott`)
+* Fixed bug in `tidy.epi.2by2` that resulted in errors with new version of `epiR` (`#1028` by `@nt-williams`)
 * Moved forward with planned deprecation of `gamlss` tidiers in favor of
 those provided in `broom.mixed`
 * Various bug fixes and improvements to documentation

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 
 # broom 0.7.6
 
-* Fixed bug in `tidy.epi.2by2` that resulted in errors with new version of `epiR` (`#1028` by `@alexpghayes`)
+* Fixed bug in `tidy.epi.2by2` that resulted in errors with new version of `epiR` (`#1028` by `@nt-williams`)
 * Fixed bug in `augment` tidiers resulting in `.fitted` and `.se.fit` array columns.
 * Fixed bug that made column `y` non-numeric after `tidy_xyz` (`#973` by `@jiho`)
 * Added tidiers for `MASS:glm.nb` (`#998` by `@joshyam-k`)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 # broom 0.7.6
 
+* Fixed bug in `tidy.epi.2by2` that resulted in errors with new version of `epiR` (`#1028` by `@alexpghayes`)
 * Fixed bug in `augment` tidiers resulting in `.fitted` and `.se.fit` array columns.
 * Fixed bug that made column `y` non-numeric after `tidy_xyz` (`#973` by `@jiho`)
 * Added tidiers for `MASS:glm.nb` (`#998` by `@joshyam-k`)

--- a/R/epiR-tidiers.R
+++ b/R/epiR-tidiers.R
@@ -44,7 +44,7 @@ tidy.epi.2by2 <- function(x, parameters = c("moa", "stat"), ...) {
   massoc <- x$massoc.detail
   out <- dplyr::bind_rows(massoc[names(massoc) != "chi2.correction"], .id = "term")
   if (rlang::arg_match(parameters) == "moa") {
-    out <- subset(out, !is.na(est), select = c(term, est, lower, upper))
+    out <- subset(out, !is.na(est), select = c("term", "est", "lower", "upper"))
     colnames(out) <- c("term", "estimate", "conf.low", "conf.high")
     return(tibble::as_tibble(out))
   }
@@ -52,7 +52,7 @@ tidy.epi.2by2 <- function(x, parameters = c("moa", "stat"), ...) {
   if ("p.value" %in% colnames(out)) {
     out$p.value.2s <- with(out, dplyr::coalesce(p.value.2s, p.value))
   }
-  out <- subset(out, is.na(est), select = c(term, test.statistic, df, p.value.2s))
+  out <- subset(out, is.na(est), select = c("term", "test.statistic", "df", "p.value.2s"))
   colnames(out) <- c("term", "statistic", "df", "p.value")
   tibble::as_tibble(out)
 }

--- a/R/epiR-tidiers.R
+++ b/R/epiR-tidiers.R
@@ -17,7 +17,7 @@
 #' )
 #'
 #' @details The tibble has a column for each of the measures of association 
-#'   or tests contained in `massoc` when [epiR::epi.2by2()] is called.
+#'   or tests contained in `massoc.detail` when [epiR::epi.2by2()] is called.
 #'
 #' @examples
 #' 
@@ -34,34 +34,25 @@
 #' )
 #'
 #' tidy(fit, parameters = "moa")
+#' tidy(fit, parameters = "stat")
 #' 
 #' @export
 #' @seealso [tidy()], [epiR::epi.2by2()]
 #' @family epiR tidiers
 #' @aliases epiR_tidiers
 tidy.epi.2by2 <- function(x, parameters = c("moa", "stat"), ...) {
+  massoc <- x$massoc.detail
+  out <- dplyr::bind_rows(massoc[names(massoc) != "chi2.correction"], .id = "term")
+  if (rlang::arg_match(parameters) == "moa") {
+    out <- subset(out, !is.na(est), select = c(term, est, lower, upper))
+    colnames(out) <- c("term", "estimate", "conf.low", "conf.high")
+    return(tibble::as_tibble(out))
+  }
   
-  s <- summary(x, ...)
-  method <- rlang::arg_match(parameters)
-  nm <- names(x$massoc)
-
-  if (method == "moa") {
-    keep <- c("measure", "est", "lower", "upper")
-    
-    out <- tibble::tibble(s, measure = nm) %>%
-      tidyr::unnest(cols = s) %>%
-      dplyr::filter(!is.na(.$est)) %>%
-      dplyr::select(keep) %>%
-      dplyr::rename_all(c("term", "estimate", "conf.low", "conf.high"))
-    
-    return(out)
-  } 
-  
-  keep <- c("measure", "test.statistic", "df", "p.value")
-  
-  tibble::tibble(s, measure = nm) %>%
-    tidyr::unnest(cols = s) %>%
-    dplyr::filter(!is.na(.$test.statistic)) %>%
-    dplyr::select(keep) %>%
-    dplyr::rename_all(c("term", "statistic", "df", "p.value"))
+  if ("p.value" %in% colnames(out)) {
+    out$p.value.2s <- with(out, dplyr::coalesce(p.value.2s, p.value))
+  }
+  out <- subset(out, is.na(est), select = c(term, test.statistic, df, p.value.2s))
+  colnames(out) <- c("term", "statistic", "df", "p.value")
+  tibble::as_tibble(out)
 }


### PR DESCRIPTION
This PR addresses issue #1028 

- [x] Documented changes in `NEWS.md`
- [x] Listed as contributer in `DESCRIPTION`
- [x] Does R-CMD-check pass
It looks like other checks were already failing. But this PR doesn't introduce any new errors, warnings, or notes and fixes previous errors caused by `tidy.epi.2by2()`

### Reprex

Using previous version of `tidy.epi.2by2()` with previous versions of `epiR`:

``` r
library(epiR)
#> Loading required package: survival
#> Package epiR 1.0-15 is loaded
#> Type help(epi.about) for summary information
#> Type browseVignettes(package = 'epiR') to learn how to use epiR for applied epidemiological analyses
#> 

dat <- matrix(c(13, 2163, 5, 3349), nrow = 2, byrow = TRUE)

rownames(dat) <- c("DF+", "DF-")
colnames(dat) <- c("FUS+", "FUS-")

fit <- epi.2by2(
  dat = as.table(dat), method = "cross.sectional",
  conf.level = 0.95, units = 100, outcome = "as.columns"
)

broom::tidy(fit)
#> # A tibble: 13 x 4
#>    term                estimate conf.low conf.high
#>    <chr>                  <dbl>    <dbl>     <dbl>
#>  1 PR.strata.wald         4.01    1.43      11.2  
#>  2 PR.strata.taylor       4.01    1.43      11.2  
#>  3 PR.strata.score        4.01    1.49      10.8  
#>  4 OR.strata.wald         4.03    1.43      11.3  
#>  5 OR.strata.cfield       4.03   NA         NA    
#>  6 OR.strata.score        4.03    1.49      10.9  
#>  7 OR.strata.mle          4.02    1.34      14.4  
#>  8 ARisk.strata.wald      0.448   0.0992     0.797
#>  9 ARisk.strata.score     0.448   0.142      0.882
#> 10 PARisk.strata.wald     0.176  -0.0225     0.375
#> 11 PARisk.strata.piri     0.176   0.0389     0.314
#> 12 AFRisk.strata.wald     0.750   0.301      0.911
#> 13 PAFRisk.strata.wald    0.542   0.0361     0.782
```

Using previous version of `tidy.epi.2by2()` with new version of `epiR` on CRAN, results in error:

``` r
library(epiR)
#> Loading required package: survival
#> Package epiR 2.0.26 is loaded
#> Type help(epi.about) for summary information
#> Type browseVignettes(package = 'epiR') to learn how to use epiR for applied epidemiological analyses
#> 

dat <- matrix(c(13, 2163, 5, 3349), nrow = 2, byrow = TRUE)

rownames(dat) <- c("DF+", "DF-")
colnames(dat) <- c("FUS+", "FUS-")

fit <- epi.2by2(
  dat = as.table(dat), method = "cross.sectional",
  conf.level = 0.95, units = 100, outcome = "as.columns"
)

broom::tidy(fit)
#> Error: Internal error in `df_slice()`: Columns must match the data frame size.
```

Now:

``` r
broom::tidy(fit)
#> # A tibble: 15 x 4
#>    term                estimate conf.low conf.high
#>    <chr>                  <dbl>    <dbl>     <dbl>
#>  1 PR.strata.wald         4.01    1.43      11.2  
#>  2 PR.strata.taylor       4.01    1.43      11.2  
#>  3 PR.strata.score        4.01    1.49      10.8  
#>  4 OR.strata.wald         4.03    1.43      11.3  
#>  5 OR.strata.cfield       4.03   NA         NA    
#>  6 OR.strata.score        4.03    1.49      10.9  
#>  7 OR.strata.mle          4.02    1.34      14.4  
#>  8 ARisk.strata.wald      0.448   0.0992     0.797
#>  9 ARisk.strata.score     0.448   0.142      0.882
#> 10 NNT.strata.wald      223.    125.      1008.   
#> 11 NNT.strata.score     223.    113.       705.   
#> 12 PARisk.strata.wald     0.176  -0.0225     0.375
#> 13 PARisk.strata.piri     0.176   0.0389     0.314
#> 14 AFRisk.strata.wald     0.750   0.301      0.911
#> 15 PAFRisk.strata.wald    0.542   0.0361     0.782
```

<sup>Created on 2021-06-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>