### PR TITLE
Added exponentiate option for `tidy.boot`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -507,7 +507,10 @@ Authors@R:
              email = "joshuayamamoto5@gmail.com"),
       person(given = "Jasme",
              family = "Lee",
-             role = "ctb"))
+             role = "ctb"),
+      person(given = "Oska"),
+             family = "Fentem",
+             role = "ctb")
 Description: Summarizes key information about statistical
     objects in tidy tibbles. This makes it easy to report results, create
     plots and consistently work with large numbers of models at once.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 To be released as broom 0.7.10.
 
 * Clarifies error when `pysch::mediate` output is dispatched to `tidy.mediate` (`#1037` by `@LukasWallrich`).
+* Added exponentiate option for `tidy.boot` (`#1040` by @oskasf)
 
 # broom 0.7.9
 

--- a/R/boot-tidiers.R
+++ b/R/boot-tidiers.R
@@ -6,6 +6,7 @@
 #' @param conf.method Passed to the `type` argument of [boot::boot.ci()].
 #'   Defaults to `"perc"`. The allowed types are `"perc"`, `"basic"`,
 #'   `"bca"`, and `"norm"`. Does not support `"stud"` or `"all"`.
+#' @template param_exponentiate
 #' @template param_unused_dots
 #'
 #' @evalRd return_tidy("bias", "std.error", "term",
@@ -50,6 +51,7 @@ tidy.boot <- function(x,
                       conf.int = FALSE,
                       conf.level = 0.95,
                       conf.method = c("perc", "bca", "basic", "norm"),
+                      exponentiate = FALSE,
                       ...) {
   conf.method <- rlang::arg_match(conf.method)
 
@@ -120,5 +122,12 @@ tidy.boot <- function(x,
     colnames(ci.tab) <- c("conf.low", "conf.high")
     ret <- cbind(ret, ci.tab)
   }
+
+  if (exponentiate){
+    ret <- dplyr::rename(ret, estimate = 2)
+    ret <- exponentiate(ret)
+    ret <- dplyr::rename(ret, statistic = 2)
+  }
+  
   as_tibble(ret)
 }

--- a/R/fixest-tidiers.R
+++ b/R/fixest-tidiers.R
@@ -55,8 +55,7 @@
 #' @family fixest tidiers
 #' @seealso [tidy()], [fixest::feglm()], [fixest::fenegbin()],
 #' [fixest::feNmlm()], [fixest::femlm()], [fixest::feols()], [fixest::fepois()]
-tidy.fixest <- function(x, conf.int = FALSE, 
-                        conf.level = 0.95, exponentiate = FALSE, ...) {
+tidy.fixest <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   coeftable <- summary(x, ...)$coeftable
   ret <- as_tibble(coeftable, rownames = "term")
   colnames(ret) <- c("term", "estimate", "std.error", "statistic", "p.value")
@@ -65,10 +64,6 @@ tidy.fixest <- function(x, conf.int = FALSE,
     # Bind to rest of tibble
     colnames(CI) <- c("conf.low", "conf.high")
     ret <- bind_cols(ret, unrowname(CI))
-  }
-  
-  if (exponentiate){
-    ret <- exponentiate(ret) 
   }
   as_tibble(ret)
 }

--- a/R/fixest-tidiers.R
+++ b/R/fixest-tidiers.R
@@ -55,7 +55,8 @@
 #' @family fixest tidiers
 #' @seealso [tidy()], [fixest::feglm()], [fixest::fenegbin()],
 #' [fixest::feNmlm()], [fixest::femlm()], [fixest::feols()], [fixest::fepois()]
-tidy.fixest <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
+tidy.fixest <- function(x, conf.int = FALSE, 
+                        conf.level = 0.95, exponentiate = FALSE, ...) {
   coeftable <- summary(x, ...)$coeftable
   ret <- as_tibble(coeftable, rownames = "term")
   colnames(ret) <- c("term", "estimate", "std.error", "statistic", "p.value")
@@ -64,6 +65,10 @@ tidy.fixest <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
     # Bind to rest of tibble
     colnames(CI) <- c("conf.low", "conf.high")
     ret <- bind_cols(ret, unrowname(CI))
+  }
+  
+  if (exponentiate){
+    ret <- exponentiate(ret) 
   }
   as_tibble(ret)
 }


### PR DESCRIPTION
@simonpcouch

Added an option to exponetiate the output of `boot::boot`. This is implemented with a crude renaming as the `exponentiate()` method requires the column to be named *estimate*.

- [x]  Have you documented the change in NEWS.md?

- [x]  If this is your first time PRing to broom, have you added yourself as a contributor in the DESCRIPTION?

- Have you added any new vocabulary to inst/WORDLIST? (New vocabulary will be noted in the R-CMD-check from GitHub Actions.) N/A

- [ ] Does R-CMD-check pass on GitHub Actions? (Sometimes, checks may not be passing on the main branch already—if that's the case, just try to make sure your changes don't add any additional errors/warnings.)

- Have you updated DESCRIPTION if your feature/bug fix requires a specific version of a package? N/A

- Have you added unit tests for any new functionality? N/A