### PR TITLE
Allow user to specify confidence level in `tidy.rma`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -507,7 +507,12 @@ Authors@R:
              email = "joshuayamamoto5@gmail.com"),
       person(given = "Jasme",
              family = "Lee",
-             role = "ctb"))
+             role = "ctb"),
+      person(given = "Taren",
+             family = "Sanders",
+             role = "ctb",
+             email = "taren.sanders@acu.edu.au",
+             comment = c(ORCID = "0000-0002-4504-6008")))
 Description: Summarizes key information about statistical
     objects in tidy tibbles. This makes it easy to report results, create
     plots and consistently work with large numbers of models at once.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 To be released as broom 0.7.10.
 
 * Clarifies error when `pysch::mediate` output is dispatched to `tidy.mediate` (`#1037` by `@LukasWallrich`).
+* Allows user to specify confidence level for `tidy.rma` (`#1041` by `@TarenSanders`)
 
 # broom 0.7.9
 

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -57,6 +57,20 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95,
     study <- "overall"
     betas <- betas[1]
   }
+  
+  if x$level != 1-conf.level {
+    level <- 1-conf.level
+    if (is.element(x$test, c("knha","adhoc","t"))) {
+      crit <- if (x$ddf > 0) qt(level/2, df=x$ddf, lower.tail=FALSE) else NA
+   } else {
+      crit <- qnorm(level/2, lower.tail=FALSE)
+     }
+    conf.low <- c(betas - crit * x$se)
+    conf.high <- c(betas + crit * x$se)
+  } else {
+    conf.low <- x$ci.lb
+    conf.high <- x$ci.ub
+  }
 
   results <- tibble::tibble(
     term = study,
@@ -65,8 +79,8 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95,
     std.error = x$se,
     statistic = x$zval,
     p.value = x$pval,
-    conf.low = x$ci.lb,
-    conf.high = x$ci.ub
+    conf.low = conf.low,
+    conf.high = conf.high
   )
 
   # tidy individual studies

--- a/R/rma-tidiers.R
+++ b/R/rma-tidiers.R
@@ -58,7 +58,7 @@ tidy.rma <- function(x, conf.int = FALSE, conf.level = 0.95,
     betas <- betas[1]
   }
   
-  if x$level != 1-conf.level {
+  if (x$level != 1-conf.level) {
     level <- 1-conf.level
     if (is.element(x$test, c("knha","adhoc","t"))) {
       crit <- if (x$ddf > 0) qt(level/2, df=x$ddf, lower.tail=FALSE) else NA


### PR DESCRIPTION
This fixes #1041 in which the argument `conf.level` is available and documented, but has no effect on the overall estimate. It uses the exact same method as `metafor` for calculating the confidence interval, to prevent mismatched CIs (from [here](https://github.com/wviechtb/metafor/blob/749687fc2b8193edfb9fc7f0b1e931eceb1b0318/R/rma.uni.r#L2131)).

I am still fairly new to GitHub, so please let me know if there's any additional changes required.

Thanks for making a pull request to broom! A few things to keep in mind that will probably help this PR be merged more quickly:  

* [x] Have you documented the change in `NEWS.md`?  
* [x] If this is your first time PRing to broom, have you added yourself as a contributor in the `DESCRIPTION`?
* Have you added any new vocabulary to `inst/WORDLIST`? (New vocabulary will be noted in the R-CMD-check from GitHub Actions.) **N/A**
* [ ] Does R-CMD-check pass on GitHub Actions? (Sometimes, checks may not be passing on the main branch already—if that's the case, just try to make sure your changes don't add any additional errors/warnings.) 
* Have you updated `DESCRIPTION` if your feature/bug fix requires a specific version of a package? **N/A**
* Have you added unit tests for any new functionality? **N/A**


