### PR TITLE
add dev mode

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -7,6 +7,9 @@ template:
     part_of: <a href="https://tidymodels.org">tidymodels</a>
     footer: broom is a part of the <strong>tidymodels</strong> ecosystem, a collection of modeling packages designed with common APIs and a shared philosophy.
 
+development:
+  mode: auto
+
 default_assets: false
 
 home:


### PR DESCRIPTION
Currently https://broom.tidymodels.org/ shows version 0.7.9.9000 as a release version while the release on CRAN is at v 0.7.9. The dev mode of pkgdown lets you show versions with four components as development versions: 

https://pkgdown.r-lib.org/reference/build_site.html?q=development%20more#development-mode