### PR TITLE
Save model index as reference point for augment. Close #1045

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ To be released as broom 0.7.10.
 * Allows user to specify confidence level for `tidy.rma` (`#1041` by `@TarenSanders`)
 * Clarifies documentation related to usage of `augment_columns()`; most package users should use `augment()` in favor of `augment_columns()`. See `?augment_columns` for more details.
 * Extends support for `emmeans` by fixing non-standard column names in case of asymptotically derived inferential statistics. (`#1046` by `@crsh`)
+* Fixes use of index columns in `augment.mlogit`. (`#1045` and `#1053` by `@jamesrrae` and `@gregmacfarlane`)
 
 # broom 0.7.9
 

--- a/R/mlogit-tidiers.R
+++ b/R/mlogit-tidiers.R
@@ -65,7 +65,7 @@ augment.mlogit <- function(x, data = x$model, ...) {
   # the ID variables are really messed up, so we're going to do some 
   # retrofitting because this ends up being a pretty important element of
   # what we want to do with the results.
-  x$model$idx
+  idx <- x$model$idx
   
   reg <- x$model %>%
     as_augment_tibble()  %>%


### PR DESCRIPTION
This is a very minor bug fix for issue #1045. 


``` r
library(mlogit)
#> Loading required package: dfidx
#> 
#> Attaching package: 'dfidx'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(broom)
data("Fishing", package = "mlogit")
fish <- dfidx(Fishing, varying = 2:9, shape = "wide", choice = "mode")
m <- mlogit(mode ~ price + catch | income, data = fish)

tidy(m)
#> # A tibble: 8 × 5
#>   term                  estimate std.error statistic  p.value
#>   <chr>                    <dbl>     <dbl>     <dbl>    <dbl>
#> 1 (Intercept):boat     0.527     0.223         2.37  1.79e- 2
#> 2 (Intercept):charter  1.69      0.224         7.56  3.95e-14
#> 3 (Intercept):pier     0.778     0.220         3.53  4.18e- 4
#> 4 price               -0.0251    0.00173     -14.5   0       
#> 5 catch                0.358     0.110         3.26  1.12e- 3
#> 6 income:boat          0.0000894 0.0000501     1.79  7.40e- 2
#> 7 income:charter      -0.0000333 0.0000503    -0.661 5.08e- 1
#> 8 income:pier         -0.000128  0.0000506    -2.52  1.18e- 2
augment(m)
#> # A tibble: 4,728 × 8
#>       id alternative chosen price  catch income .probability .fitted
#>    <int> <fct>       <lgl>  <dbl>  <dbl>  <dbl>        <dbl>   <dbl>
#>  1     1 beach       FALSE  158.  0.0678  7083.      0.125    -3.94 
#>  2     1 boat        FALSE  158.  0.260   7083.      0.427    -2.71 
#>  3     1 charter     TRUE   183.  0.539   7083.      0.339    -2.94 
#>  4     1 pier        FALSE  158.  0.0503  7083.      0.109    -4.07 
#>  5     2 beach       FALSE   15.1 0.105   1250.      0.116    -0.342
#>  6     2 boat        FALSE   10.5 0.157   1250.      0.251     0.431
#>  7     2 charter     TRUE    34.5 0.467   1250.      0.423     0.952
#>  8     2 pier        FALSE   15.1 0.0451  1250.      0.210     0.255
#>  9     3 beach       FALSE  162.  0.533   3750.      0.00689  -3.87 
#> 10     3 boat        TRUE    24.3 0.241   3750.      0.465     0.338
#> # … with 4,718 more rows
glance(m)
#> # A tibble: 1 × 6
#>   logLik  rho2 rho20   AIC   BIC  nobs
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <int>
#> 1 -1215. 0.189 0.258 2446.    NA  1182
```

<sup>Created on 2021-09-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
