### PR TITLE
Remove duplicate `id_cols` in lavaan `glance()` method

### DIFF
--- a/R/lavaan-tidiers.R
+++ b/R/lavaan-tidiers.R
@@ -140,7 +140,7 @@ glance.lavaan <- function(x, ...) {
         )
     ) %>%
     tibble::enframe(name = "term") %>%
-    pivot_wider(id_cols = term, names_from = term, values_from = value) %>%
+    pivot_wider(names_from = term, values_from = value) %>%
     select(order(colnames(.))) %>%
     map_df(as.numeric) %>%
     bind_cols(


### PR DESCRIPTION
@simonpcouch, we are planning a release of tidyr in mid January, and {lcsm} was flagged as a broken revdep. It seems to be broken because of this broom issue. For some reason, `terms` was being supplied as both `id_cols` and `names_from`. This previously didn't do anything (`id_cols` became `character()` silently), but now it is an error because it seems like this is always unintentional.

It looks like `terms` should have only been supplied for `names_from`. If I make this change, {lcsm} passes cleanly again.

I would really appreciate it if you could merge this and possibly prepare a small patch release of broom for early January so we can release tidyr with minimal issues! Thanks!