### PR TITLE
ensure roxygen2 descriptions use consistent punctuation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -641,7 +641,7 @@ Config/Needs/website:
     tidyverse/tidytemplate    
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Language: en-US
 Collate:
     'aaa-documentation-helper.R'

--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -35,15 +35,15 @@
 #'   components in the original space. The columns are:
 #'
 #'   \item{`row`}{The variable labels (colnames) of the data set on
-#'   which PCA was performed}
-#'   \item{`PC`}{An integer vector indicating the principal component}
+#'   which PCA was performed.}
+#'   \item{`PC`}{An integer vector indicating the principal component.}
 #'   \item{`value`}{The value of the eigenvector (axis score) on the
-#'   indicated principal component}
+#'   indicated principal component.}
 #'
 #'   If `matrix` is `"d"`, `"eigenvalues"` or `"pcs"`, the columns are:
 #'
-#'   \item{`PC`}{An integer vector indicating the principal component}
-#'   \item{`std.dev`}{Standard deviation explained by this PC}
+#'   \item{`PC`}{An integer vector indicating the principal component.}
+#'   \item{`std.dev`}{Standard deviation explained by this PC.}
 #'   \item{`percent`}{Fraction of variation explained by this component
 #'     (a numeric value between 0 and 1).}
 #'   \item{`cumulative`}{Cumulative fraction of variation explained by

--- a/man/tidy.prcomp.Rd
+++ b/man/tidy.prcomp.Rd
@@ -51,15 +51,15 @@ row in the tidied output corresponds to information about the principle
 components in the original space. The columns are:
 
 \item{\code{row}}{The variable labels (colnames) of the data set on
-which PCA was performed}
-\item{\code{PC}}{An integer vector indicating the principal component}
+which PCA was performed.}
+\item{\code{PC}}{An integer vector indicating the principal component.}
 \item{\code{value}}{The value of the eigenvector (axis score) on the
-indicated principal component}
+indicated principal component.}
 
 If \code{matrix} is \code{"d"}, \code{"eigenvalues"} or \code{"pcs"}, the columns are:
 
-\item{\code{PC}}{An integer vector indicating the principal component}
-\item{\code{std.dev}}{Standard deviation explained by this PC}
+\item{\code{PC}}{An integer vector indicating the principal component.}
+\item{\code{std.dev}}{Standard deviation explained by this PC.}
 \item{\code{percent}}{Fraction of variation explained by this component
 (a numeric value between 0 and 1).}
 \item{\code{cumulative}}{Cumulative fraction of variation explained by

--- a/man/tidy_irlba.Rd
+++ b/man/tidy_irlba.Rd
@@ -40,15 +40,15 @@ row in the tidied output corresponds to information about the principle
 components in the original space. The columns are:
 
 \item{\code{row}}{The variable labels (colnames) of the data set on
-which PCA was performed}
-\item{\code{PC}}{An integer vector indicating the principal component}
+which PCA was performed.}
+\item{\code{PC}}{An integer vector indicating the principal component.}
 \item{\code{value}}{The value of the eigenvector (axis score) on the
-indicated principal component}
+indicated principal component.}
 
 If \code{matrix} is \code{"d"}, \code{"eigenvalues"} or \code{"pcs"}, the columns are:
 
-\item{\code{PC}}{An integer vector indicating the principal component}
-\item{\code{std.dev}}{Standard deviation explained by this PC}
+\item{\code{PC}}{An integer vector indicating the principal component.}
+\item{\code{std.dev}}{Standard deviation explained by this PC.}
 \item{\code{percent}}{Fraction of variation explained by this component
 (a numeric value between 0 and 1).}
 \item{\code{cumulative}}{Cumulative fraction of variation explained by

--- a/man/tidy_svd.Rd
+++ b/man/tidy_svd.Rd
@@ -51,15 +51,15 @@ row in the tidied output corresponds to information about the principle
 components in the original space. The columns are:
 
 \item{\code{row}}{The variable labels (colnames) of the data set on
-which PCA was performed}
-\item{\code{PC}}{An integer vector indicating the principal component}
+which PCA was performed.}
+\item{\code{PC}}{An integer vector indicating the principal component.}
 \item{\code{value}}{The value of the eigenvector (axis score) on the
-indicated principal component}
+indicated principal component.}
 
 If \code{matrix} is \code{"d"}, \code{"eigenvalues"} or \code{"pcs"}, the columns are:
 
-\item{\code{PC}}{An integer vector indicating the principal component}
-\item{\code{std.dev}}{Standard deviation explained by this PC}
+\item{\code{PC}}{An integer vector indicating the principal component.}
+\item{\code{std.dev}}{Standard deviation explained by this PC.}
 \item{\code{percent}}{Fraction of variation explained by this component
 (a numeric value between 0 and 1).}
 \item{\code{cumulative}}{Cumulative fraction of variation explained by


### PR DESCRIPTION
Added a few punctuations for the sake of documentation consistency.
