### PR TITLE
Survey pkg tidy update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ While broom 0.8.0 does not introduce much in terms of new functionality or break
 * Clarify errors and warnings for deprecated tidiers.
 * Ensure that tidiers are placed in files named according to the model-supplying package rather than the model object class for easier navigability of the source code.
 
+* Update in `tidy.htest()` converting matrix-columns to vector-columns. (#1081)
+
 # broom 0.7.12
 
 Nearly identical source to broom 0.7.11—updates the maintainer email address to an address listed in other CRAN packages maintained by the same person.

--- a/R/broom-package.R
+++ b/R/broom-package.R
@@ -26,3 +26,4 @@
 #' @keywords internal
 "_PACKAGE"
 
+utils::globalVariables("where")

--- a/R/stats-htest-tidiers.R
+++ b/R/stats-htest-tidiers.R
@@ -95,7 +95,9 @@ tidy.htest <- function(x, ...) {
   if (!is.null(x$alternative)) {
     ret <- c(ret, alternative = as.character(x$alternative))
   }
-  as_tibble(ret)
+  as_tibble(ret) %>%
+    # convert matrix columns to vector columns (see GH Issue #1081)
+    dplyr::mutate(dplyr::across(where(is.matrix), c))
 }
 
 

--- a/tests/testthat/test-stats-htest.R
+++ b/tests/testthat/test-stats-htest.R
@@ -117,3 +117,14 @@ test_that("augment.htest (chi squared test)", {
     regexp = "Augment is only defined for chi squared hypothesis tests."
   )
 })
+
+test_that("tidy.htest does not return matrix columns", {
+  data(api, package = "survey")
+  dclus1 <- survey::svydesign(id = ~dnum, weights = ~pw, data = apiclus1, fpc = ~fpc)
+  
+  expect_true(
+    survey::svychisq(~sch.wide + stype, design = dclus1, statistic = "Wald") %>%
+      tidy() %>%
+      purrr::none(~inherits(., "matrix"))
+  )
+})


### PR DESCRIPTION
**Have you documented the change in `NEWS.md`?**
Yes :)

**If this is your first time PRing to broom, have you added yourself as a contributor in the `DESCRIPTION`?**
Already listed :)

**Have you added any new vocabulary to `inst/WORDLIST`? (New vocabulary will be noted in the R-CMD-check from GitHub Actions.)**
I did not add any documentation or words flagged by the spell check. There are two words, however, already in the package that do get flagged by the spell checker: lifecycle and workshopped. Both recent additions in the NEWS.md file. I did not add these to the WORDLIST in case the phrasing is updated prior to release.

**Does R-CMD-check pass on GitHub Actions? (Sometimes, checks may not be passing on the main branch already—if that's the case, just try to make sure your changes don't add any additional errors/warnings.)**
I tested locally, and there were failures both before and after my update in the `test-fixest.R` file.

**Have you updated `DESCRIPTION` if your feature/bug fix requires a specific version of a package?**
Not applicable

**Have you added unit tests for any new functionality?**
Yes, a unit test has been added to `test-stats-htest.R`

**If your PR fixes a bug, a [reprex](https://github.com/tidyverse/reprex) of the bug would be much appreciated!**
Example showing the matrix columns have been removed.
``` r
data(api, package = "survey")
dclus1 <- survey::svydesign(id = ~dnum, weights = ~pw, data = apiclus1, fpc = ~fpc)
x <- survey::svychisq(~sch.wide + stype, dclus1, statistic = "Wald")

# no matrix columns in output
broom::tidy(x)
#> Multiple parameters; naming those columns ndf, ddf
#> # A tibble: 1 x 5
#>     ndf   ddf statistic p.value method                               
#>   <dbl> <dbl>     <dbl>   <dbl> <chr>                                
#> 1     2    14      2.40   0.127 Design-based Wald test of association
```

<sup>Created on 2022-02-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


**If your PR adds new tidiers for external model objects, please link to prior attempts to add these tidiers to the model-exporting package, and include a reprex of the new tidiers' functionality! You can learn more about writing tidiers for model-exporting packages [here](https://www.tidymodels.org/learn/develop/broom/).**
Not applicable

