### PR TITLE
tidy.speedlm message on left_join(by = ...)

### DIFF
--- a/R/speedglm-speedlm-tidiers.R
+++ b/R/speedglm-speedlm-tidiers.R
@@ -38,7 +38,7 @@ tidy.speedlm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   # summary(x)$coefficients misses rank deficient rows (i.e. coefs that
   # summary.lm() sets to NA), catch them here and add them back
   coefs <- tibble::enframe(stats::coef(x), name = "term", value = "estimate")
-  ret <- left_join(coefs, ret)
+  ret <- left_join(coefs, ret, by = c("term", "estimate"))
 
   if (conf.int) {
     ci <- broom_confint_terms(x, level = conf.level)


### PR DESCRIPTION
https://github.com/tidymodels/broom/issues/1084

The issue was that `left_join()` was called without specifying the `by` argument, which produced a lot of noise.