### PR TITLE
Bug #1018: glance.fixest catches error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ While broom 0.8.0 does not introduce much in terms of new functionality or break
 * Clarify errors and warnings for deprecated tidiers.
 * Ensure that tidiers are placed in files named according to the model-supplying package rather than the model object class for easier navigability of the source code.
 
+### Bug fixes
+
+* Addressed `glance.fixest` error when model includes only fixed effects and no regressors.
+
 # broom 0.7.12
 
 Nearly identical source to broom 0.7.11—updates the maintainer email address to an address listed in other CRAN packages maintained by the same person.

--- a/R/fixest-tidiers.R
+++ b/R/fixest-tidiers.R
@@ -174,7 +174,8 @@ glance.fixest <- function(x, ...) {
     res_specific <- with(
       summary(x, ...),
       tibble(
-        sigma = sqrt(sigma2),
+        # catch error in models with only fixed effects and no regressors
+        sigma = tryCatch(sqrt(sigma2), error = function(e) NA_real_),
         pseudo.r.squared = NA_real_, # always NA for OLS
       )
     )

--- a/tests/testthat/test-fixest.R
+++ b/tests/testthat/test-fixest.R
@@ -30,6 +30,12 @@ test_that("fixest tidier arguments", {
   check_arguments(augment.fixest)
 })
 
+test_that("bug #1018: fixed effects but no regressors", {
+    mod <- feols(Sepal.Length ~ 1 | Species, data = iris)
+    check_tidy_output(tidy(mod))
+    check_glance_outputs(glance(mod))
+})
+
 test_that("tidy.fixest", {
   td <- tidy(fit)
   td2 <- tidy(fit2, conf.int = TRUE)


### PR DESCRIPTION
https://github.com/tidymodels/broom/issues/1018

When a `fixest` model includes only fixed effects and no regressors `sigma2` does not exist and `glance.fixest()` errors. I use `tryCatch` to return `NA_real_` instead. I also added a test.