### PR TITLE
clarify warning for un-maintained tidiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ While broom 0.8.0 does not introduce much in terms of new functionality or break
      - All tidiers now have example code demonstrating usage in their documentation. Tidiers for base packages as well as selected others also include sample code for visualization of results with ggplot2.
      - Code examples in the documentation largely now follow consistent style---these changes were made largely to reflect the tidyverse style guide, addressing spacing, object naming, and commenting, among other things.
      - Examples previously marked with `\dontrun` or `\donttest` have been workshopped to run reliably.
-* Clarify errors and warnings for deprecated tidiers.
+* Clarify errors and warnings for deprecated and un-maintained tidiers.
 * Ensure that tidiers are placed in files named according to the model-supplying package rather than the model object class for easier navigability of the source code.
 
 ### Bug fixes and other improvements

--- a/R/stats-glm-tidiers.R
+++ b/R/stats-glm-tidiers.R
@@ -13,7 +13,7 @@ tidy.glm <- function(x, conf.int = FALSE, conf.level = .95,
                      exponentiate = FALSE, ...) {
   
   warn_on_appropriated_glm_class(x)
-  warn_on_subclass(x)
+  warn_on_subclass(x, "tidy")
   
   ret <- as_tibble(summary(x)$coefficients, rownames = "term")
   colnames(ret) <- c("term", "estimate", "std.error", "statistic", "p.value")
@@ -75,7 +75,7 @@ augment.glm <- function(x,
                         type.residuals = c("deviance", "pearson"),
                         se_fit = FALSE, ...) {
   warn_on_appropriated_glm_class(x)
-  warn_on_subclass(x)
+  warn_on_subclass(x, "augment")
   
   type.predict <- rlang::arg_match(type.predict)
   type.residuals <- rlang::arg_match(type.residuals)
@@ -136,7 +136,7 @@ augment.glm <- function(x,
 #' @seealso [stats::glm()]
 glance.glm <- function(x, ...) {
   warn_on_appropriated_glm_class(x)
-  warn_on_subclass(x)
+  warn_on_subclass(x, "glance")
   
   as_glance_tibble(
     null.deviance = x$null.deviance,

--- a/R/stats-lm-tidiers.R
+++ b/R/stats-lm-tidiers.R
@@ -91,7 +91,7 @@
 #' @family lm tidiers
 tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
 
-  warn_on_subclass(x)
+  warn_on_subclass(x, "tidy")
 
   ret <- as_tibble(summary(x)$coefficients, rownames = "term")
   colnames(ret) <- c("term", "estimate", "std.error", "statistic", "p.value")
@@ -143,7 +143,7 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
 augment.lm <- function(x, data = model.frame(x), newdata = NULL,
                        se_fit = FALSE, interval =  c("none", "confidence", "prediction"), ...) {
   
-  warn_on_subclass(x)
+  warn_on_subclass(x, "augment")
   
   interval <- match.arg(interval)
   df <- augment_newdata(x, data, newdata, se_fit, interval)
@@ -190,7 +190,7 @@ augment.lm <- function(x, data = model.frame(x), newdata = NULL,
 #' @family lm tidiers
 glance.lm <- function(x, ...) {
   
-  warn_on_subclass(x)
+  warn_on_subclass(x, "glance")
   
   # check whether the model was fitted with only an intercept, in which
   # case drop the fstatistic related columns

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -485,15 +485,15 @@ broom_confint_terms <- function(x, ...) {
 }
 
 # warn when models subclasses glm/lm and do not have their own dedicated tidiers.
-warn_on_subclass <- function(x) {
+warn_on_subclass <- function(x, tidier) {
   if (length(class(x)) > 1 && class(x)[1] != "glm") {
     subclass <- class(x)[1]
     dispatched_method <- class(x)[class(x) %in% c("glm", "lm")][1]
     
     warning(
-      "Tidiers for objects of class ", 
+      "The `", tidier, "()` method for objects of class ", 
       subclass, 
-      " are not maintained by the broom team, and are only supported through ",
+      " is not maintained by the broom team, and is only supported through ",
       "the ", 
       dispatched_method, 
       " tidier method. Please be cautious in interpreting and reporting ",

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -93,14 +93,14 @@ test_that("appropriate warning on (g)lm-subclassed models", {
   class(x) <- c("gee", "glm")
   
   expect_warning(
-    warn_on_subclass(x),
+    warn_on_subclass(x, "tidy"),
     "only supported through the glm tidier method."
   )
   
   class(x) <- c("gee", "glm", "lm")
   
   expect_warning(
-    warn_on_subclass(x),
+    warn_on_subclass(x, "tidy"),
     "only supported through the glm tidier method."
   )
 })


### PR DESCRIPTION
re: #1078, workshop the warning for tidiers only supported via `lm`/`glm` to be clear that some tidiers for a class may be "officially" maintained while others of the same class only receive support via dispatch. What used to read:

```
Warning message:
Tidiers for objects of class svyglm are not maintained by the broom team, and are only 
supported through the glm tidier method. Please be cautious in interpreting and 
reporting broom output. 
```

now reads:

```
Warning message:
The `augment()` method for objects of class svyglm is not maintained by the broom 
team, and is only supported through the glm tidier method. Please be cautious in 
interpreting and reporting broom output. 
```