### PR TITLE
transition interpolation tidiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -555,7 +555,6 @@ Imports:
     ggplot2
 Suggests:
     AER,
-    akima,
     AUC,
     bbmle,
     betareg,
@@ -583,6 +582,7 @@ Suggests:
     gmm,
     Hmisc,
     irlba,
+    interp,
     joineRML,
     Kendall,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@ Other fixes and improvements:
 * Address failures in `tidy.glht()` with `conf.int = TRUE` (#1103).
 * Address failures in `tidy.zoo()` when input data does not have `colnames` 
   (#1080).
+* Transition tidiers for bivariate linear or spline-based interpolation---using
+  list tidiers to interface with objects from the akima package is now 
+  considered off-label. See the interp package for a FOSS alternative.
 
 # broom 0.8.0
 

--- a/R/list-tidiers.R
+++ b/R/list-tidiers.R
@@ -2,7 +2,7 @@
 #'
 #' Broom tidies a number of lists that are effectively S3 objects without
 #' a class attribute. For example, [stats::optim()], [base::svd()] and
-#' [akima::interp()] produce consistent output, but because they do not
+#' [interp::interp()] produce consistent output, but because they do not
 #' have a class attribute, they cannot be handled by S3 dispatch.
 #'
 #' These functions look at the elements of a list and determine if there is

--- a/R/list-xyz-tidiers.R
+++ b/R/list-xyz-tidiers.R
@@ -4,7 +4,7 @@
 #' @description xyz lists (lists where `x` and `y` are vectors of coordinates
 #'   and `z` is a matrix of values) are typically used by functions such as
 #'   [graphics::persp()] or [graphics::image()] and returned
-#'   by interpolation functions such as [akima::interp()].
+#'   by interpolation functions such as [interp::interp()].
 #'
 #' @param x A list with component `x`, `y` and `z`, where `x` and `y` are
 #'   vectors and `z` is a matrix. The length of `x` must equal the number of
@@ -21,7 +21,7 @@
 #' @aliases xyz_tidiers
 #' @family list tidiers
 #' @seealso [tidy()], [graphics::persp()], [graphics::image()],
-#'   [akima::interp()]
+#'   [interp::interp()]
 #'
 tidy_xyz <- function(x, ...) {
   if (!is.matrix(x$z)) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,7 @@
 aareg
 acf
 AER
+akima
 Andreas
 anova
 aov
@@ -77,6 +78,7 @@ Fhat
 fitdistr
 fixest
 fn
+FOSS
 frankenstein
 ftable
 funder
@@ -108,6 +110,7 @@ infl
 ing
 io
 irlba
+interp
 ivreg
 Jarque
 joineRML

--- a/man-roxygen/title_desc_tidy_list.R
+++ b/man-roxygen/title_desc_tidy_list.R
@@ -2,7 +2,7 @@
 #' 
 #' @description Broom tidies a number of lists that are effectively S3
 #'   objects without a class attribute. For example, [stats::optim()],
-#'   [svd()][base::svd()] and [akima::interp()] produce consistent output, but 
+#'   [svd()][base::svd()] and [interp::interp()] produce consistent output, but 
 #'   because they do not have a class attribute, they cannot be handled by S3 
 #'   dispatch.
 #' 

--- a/man/glance_optim.Rd
+++ b/man/glance_optim.Rd
@@ -26,7 +26,7 @@ will be ignored.
 \description{
 Broom tidies a number of lists that are effectively S3
 objects without a class attribute. For example, \code{\link[stats:optim]{stats::optim()}},
-\link[base:svd]{svd()} and \code{\link[akima:interp]{akima::interp()}} produce consistent output, but
+\link[base:svd]{svd()} and \code{\link[interp:interp]{interp::interp()}} produce consistent output, but
 because they do not have a class attribute, they cannot be handled by S3
 dispatch.
 

--- a/man/list_tidiers.Rd
+++ b/man/list_tidiers.Rd
@@ -18,7 +18,7 @@
 \description{
 Broom tidies a number of lists that are effectively S3 objects without
 a class attribute. For example, \code{\link[stats:optim]{stats::optim()}}, \code{\link[base:svd]{base::svd()}} and
-\code{\link[akima:interp]{akima::interp()}} produce consistent output, but because they do not
+\code{\link[interp:interp]{interp::interp()}} produce consistent output, but because they do not
 have a class attribute, they cannot be handled by S3 dispatch.
 }
 \details{

--- a/man/tidy_irlba.Rd
+++ b/man/tidy_irlba.Rd
@@ -61,7 +61,7 @@ principle components up to this component (a numeric value between 0 and
 \description{
 Broom tidies a number of lists that are effectively S3
 objects without a class attribute. For example, \code{\link[stats:optim]{stats::optim()}},
-\link[base:svd]{svd()} and \code{\link[akima:interp]{akima::interp()}} produce consistent output, but
+\link[base:svd]{svd()} and \code{\link[interp:interp]{interp::interp()}} produce consistent output, but
 because they do not have a class attribute, they cannot be handled by S3
 dispatch.
 

--- a/man/tidy_optim.Rd
+++ b/man/tidy_optim.Rd
@@ -27,7 +27,7 @@ will be ignored.
 \description{
 Broom tidies a number of lists that are effectively S3
 objects without a class attribute. For example, \code{\link[stats:optim]{stats::optim()}},
-\link[base:svd]{svd()} and \code{\link[akima:interp]{akima::interp()}} produce consistent output, but
+\link[base:svd]{svd()} and \code{\link[interp:interp]{interp::interp()}} produce consistent output, but
 because they do not have a class attribute, they cannot be handled by S3
 dispatch.
 

--- a/man/tidy_svd.Rd
+++ b/man/tidy_svd.Rd
@@ -72,7 +72,7 @@ principle components up to this component (a numeric value between 0 and
 \description{
 Broom tidies a number of lists that are effectively S3
 objects without a class attribute. For example, \code{\link[stats:optim]{stats::optim()}},
-\link[base:svd]{svd()} and \code{\link[akima:interp]{akima::interp()}} produce consistent output, but
+\link[base:svd]{svd()} and \code{\link[interp:interp]{interp::interp()}} produce consistent output, but
 because they do not have a class attribute, they cannot be handled by S3
 dispatch.
 

--- a/man/tidy_xyz.Rd
+++ b/man/tidy_xyz.Rd
@@ -31,7 +31,7 @@ A \link[tibble:tibble]{tibble::tibble} with vector columns \code{x}, \code{y} an
 \description{
 Broom tidies a number of lists that are effectively S3
 objects without a class attribute. For example, \code{\link[stats:optim]{stats::optim()}},
-\link[base:svd]{svd()} and \code{\link[akima:interp]{akima::interp()}} produce consistent output, but
+\link[base:svd]{svd()} and \code{\link[interp:interp]{interp::interp()}} produce consistent output, but
 because they do not have a class attribute, they cannot be handled by S3
 dispatch.
 
@@ -45,7 +45,7 @@ If no appropriate tidying method is found, they throw an error.
 xyz lists (lists where \code{x} and \code{y} are vectors of coordinates
 and \code{z} is a matrix of values) are typically used by functions such as
 \code{\link[graphics:persp]{graphics::persp()}} or \code{\link[graphics:image]{graphics::image()}} and returned
-by interpolation functions such as \code{\link[akima:interp]{akima::interp()}}.
+by interpolation functions such as \code{\link[interp:interp]{interp::interp()}}.
 }
 \examples{
 
@@ -55,7 +55,7 @@ tidy(A)
 }
 \seealso{
 \code{\link[=tidy]{tidy()}}, \code{\link[graphics:persp]{graphics::persp()}}, \code{\link[graphics:image]{graphics::image()}},
-\code{\link[akima:interp]{akima::interp()}}
+\code{\link[interp:interp]{interp::interp()}}
 
 Other list tidiers: 
 \code{\link{glance_optim}()},


### PR DESCRIPTION
re: notification from CRAN:

Transitions tidiers for bivariate linear or spline-based interpolation—using list tidiers to interface with objects from the akima package is now considered off-label. See the interp package for a FOSS alternative.