### PR TITLE
Improve performance of tidy.lm and tidy.glm for full-rank fits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -523,7 +523,12 @@ Authors@R:
              family = "Sjoberg",
              role = "ctb",
              email = "danield.sjoberg@gmail.com",
-             comment = c(ORCID = "0000-0003-0862-2018")))
+             comment = c(ORCID = "0000-0003-0862-2018")),
+      person(given = "Alex",
+             family = "Reinhart",
+             role = "ctb",
+             email = "areinhar@stat.cmu.edu",
+             comment = c(ORCID = "0000-0002-6658-514X")))
 Description: Summarizes key information about statistical
     objects in tidy tibbles. This makes it easy to report results, create
     plots and consistently work with large numbers of models at once.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 To be released as broom 1.0.1.
 
+* Improves performance of `tidy.lm()` and `tidy.glm()` for full-rank fits (#1112 by `@capnrefsmmat`).
+
 # broom 1.0.0
 
 broom 1.0.0 is the first "production" release of the broom package, and includes a number of notable changes to both functionality and governance.

--- a/tests/testthat/test-stats-glm.R
+++ b/tests/testthat/test-stats-glm.R
@@ -15,19 +15,26 @@ gfit <- glm(am ~ wt, mtcars, family = "binomial")
 gfit2 <- glm(cyl ~ wt + log(disp), mtcars, family = "poisson")
 gfit3 <- glm(am ~ wt, mtcars, family = "binomial", weights = glm_weights)
 
+# the gear term isn't defined for this fit
+na_row_data <- mtcars[c(1, 2, 13:15, 22), ]
+gfit_na_row <- glm(am ~ cyl * qsec + gear, data = na_row_data)
+
 test_that("tidy.glm works", {
   td <- tidy(gfit)
   td2 <- tidy(gfit2)
   tde <- tidy(gfit, exponentiate = TRUE)
   tde2 <- tidy(gfit2, exponentiate = TRUE)
+  td_na_row <- tidy(gfit_na_row)
 
   check_tidy_output(td)
   check_tidy_output(td2)
   check_tidy_output(tde)
   check_tidy_output(tde2)
+  check_tidy_output(td_na_row)
 
   check_dims(td, 2, 5)
   check_dims(td2, 3, 5)
+  check_dims(td_na_row, expected_rows = 5)
 
   expect_equal(td$term, c("(Intercept)", "wt"))
   expect_equal(td2$term, c("(Intercept)", "wt", "log(disp)"))

--- a/tests/testthat/test-stats-lm.R
+++ b/tests/testthat/test-stats-lm.R
@@ -29,6 +29,7 @@ test_that("tidy.lm works", {
   td <- tidy(fit)
   td2 <- tidy(fit2)
   td3 <- tidy(fit3)
+  td_na_row <- tidy(fit_na_row)
 
   # conf.int = TRUE works for rank deficient fits
   # should get a "NaNs produced" warning
@@ -38,10 +39,12 @@ test_that("tidy.lm works", {
   check_tidy_output(td2)
   check_tidy_output(td3)
   check_tidy_output(td_rd)
+  check_tidy_output(td_na_row)
 
   check_dims(td, expected_rows = 2)
   check_dims(td2, expected_rows = 3)
   check_dims(td3, expected_rows = 1)
+  check_dims(td_na_row, expected_rows = 5)
 
   expect_equal(td$term, c("(Intercept)", "wt"))
   expect_equal(td2$term, c("(Intercept)", "wt", "log(disp)"))


### PR DESCRIPTION
tidy.lm and tidy.glm use summary(x)$coefficients, then join with coef(x)
to handle the case where the fit is rank deficient and some terms with
NA coefficients are missing from summary(x)$coefficients. However, in a
simple experiment, the left_join() consumes a disproportionate amount of
time. Only run the left_join() when the fit is rank-deficient and it is
necessary, and add tests to ensure the rows are added correctly for
rank-deficient fits.

An example:

```
library(broom)
library(profvis)

profvis(replicate(1000, tidy(lm(dist ~ speed, data = cars))))
```

Before this change, the expression ran in 3470 ms, of which 2570
ms (74%) was in tidy.lm() and 1590 ms (46%) was in
left_join.data.frame(). After this change, the expression ran in 1740
ms, of which 1010 ms was in tidy.lm(), cutting 60% from the total time
in tidy.lm(). This is useful for simulation studies that use tidy() to
get estimates for each simulated fit.

Thanks for making a pull request to broom! A few things to keep in mind that will probably help this PR be merged more quickly:  

* [ ] Have you documented the change in `NEWS.md`?  
  * As this doesn't change any user-facing API, I haven't, but can add it if performance changes are significant
* [x] If this is your first time PRing to broom, have you added yourself as a contributor in the `DESCRIPTION`?
* [x] Have you added any new vocabulary to `inst/WORDLIST`? (New vocabulary will be noted in the R-CMD-check from GitHub Actions.)
* [ ] Does R-CMD-check pass on GitHub Actions? (Sometimes, checks may not be passing on the main branch already—if that's the case, just try to make sure your changes don't add any additional errors/warnings.) 
* [x] Have you updated `DESCRIPTION` if your feature/bug fix requires a specific version of a package?
* [x] Have you added unit tests for any new functionality?
