### PR TITLE
Migrate `ggplot2` from strong to weak dependency

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -50,6 +50,7 @@ jobs:
             any::testthat
             any::knitr
             any::rmarkdown
+            any::ggplot2
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -50,7 +50,6 @@ jobs:
             any::testthat
             any::knitr
             any::rmarkdown
-            any::ggplot2
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -551,8 +551,7 @@ Imports:
     rlang,
     stringr,
     tibble (>= 3.0.0),
-    tidyr (>= 1.0.0),
-    ggplot2
+    tidyr (>= 1.0.0)
 Suggests:
     AER,
     AUC,
@@ -578,6 +577,7 @@ Suggests:
     gam (>= 1.15),
     gee,
     geepack,
+    ggplot2,
     glmnet,
     glmnetUtils,
     gmm,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # broom 1.0.1.9000
 
+* Migrated 'ggplot2' from strong to weak dependency, i.e. moved from `Imports` to `Suggests`.
+
 To be released as broom 1.0.2.
 
 # broom 1.0.1

--- a/R/auc-tidiers.R
+++ b/R/auc-tidiers.R
@@ -6,7 +6,7 @@
 #'
 #' @evalRd return_tidy("cutoff", "tpr", "fpr")
 #'
-#' @examplesIf rlang::is_installed("AUC")
+#' @examplesIf rlang::is_installed(c("AUC", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(AUC)

--- a/R/bingroup-tidiers.R
+++ b/R/bingroup-tidiers.R
@@ -42,9 +42,7 @@ tidy.binWidth <- function(x, ...) {
 #'   power = "Power achieved for given value of n."
 #' )
 #'
-#' @examples
-#' 
-#' if (requireNamespace("binGroup", quietly = TRUE)) {
+#' @examplesIf rlang::is_installed(c("binGroup", "ggplot2"))
 #'
 #' library(binGroup)
 #' des <- binDesign(
@@ -60,7 +58,6 @@ tidy.binWidth <- function(x, ...) {
 #' ggplot(tidy(des), aes(n, power)) +
 #'   geom_line()
 #'   
-#' }
 #' 
 #' @export
 #' @family bingroup tidiers
@@ -85,7 +82,7 @@ tidy.binDesign <- function(x, ...) {
 #'   maxit = "Number of iterations performed."
 #' )
 #'
-#' @examplesIf rlang::is_installed("binGroup")
+#' @examplesIf rlang::is_installed(c("binGroup", "ggplot2"))
 #' 
 #' # load libraries for models and data
 #' library(binGroup)

--- a/R/broom-package.R
+++ b/R/broom-package.R
@@ -26,7 +26,3 @@
 #' @keywords internal
 "_PACKAGE"
 
-# address unused Imports warning from R CMD check
-import_ggplot <- function() {
-  ggplot2::aes()
-}

--- a/R/cluster-tidiers.R
+++ b/R/cluster-tidiers.R
@@ -25,7 +25,7 @@
 #' @seealso [tidy()], [cluster::pam()]
 #' @family pam tidiers
 # skip running examples - occasionally over CRAN check time limit
-#' @examplesIf (rlang::is_installed("cluster") & rlang::is_installed("modeldata") && identical(Sys.getenv("NOT_CRAN"), "true"))
+#' @examplesIf (rlang::is_installed(c("cluster", "modeldata", "ggplot2")) && identical(Sys.getenv("NOT_CRAN"), "true"))
 #'
 #' # load libraries for models and data
 #' library(dplyr)

--- a/R/deprecated-0-7-0.R
+++ b/R/deprecated-0-7-0.R
@@ -32,7 +32,7 @@
 #' kurtosis and related tests. R package version 0.14. \cr
 #' https://CRAN.R-project.org/package=moments
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' td <- tidy(mtcars)
 #' td

--- a/R/emmeans-tidiers.R
+++ b/R/emmeans-tidiers.R
@@ -26,7 +26,7 @@
 #'   There are a large number of arguments that can be
 #'   passed on to [emmeans::summary.emmGrid()] or [lsmeans::summary.ref.grid()].
 #'
-#' @examplesIf rlang::is_installed("emmeans")
+#' @examplesIf rlang::is_installed(c("emmeans", "ggplot2"))
 #' 
 #' # load libraries for models and data
 #' library(emmeans)

--- a/R/glmnet-cv-glmnet-tidiers.R
+++ b/R/glmnet-cv-glmnet-tidiers.R
@@ -16,7 +16,7 @@
 #'     lamdba"
 #' )
 #'
-#' @examplesIf rlang::is_installed("glmnet")
+#' @examplesIf rlang::is_installed(c("glmnet", "ggplot2"))
 #' 
 #' # load libraries for models and data
 #' library(glmnet)

--- a/R/glmnet-glmnet-tidiers.R
+++ b/R/glmnet-glmnet-tidiers.R
@@ -24,7 +24,7 @@
 #'   logical. Furthermore, predictions make sense only with a specific
 #'   choice of lambda.
 #'
-#' @examplesIf rlang::is_installed("glmnet")
+#' @examplesIf rlang::is_installed(c("glmnet", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(glmnet)

--- a/R/gmm-tidiers.R
+++ b/R/gmm-tidiers.R
@@ -8,7 +8,7 @@
 #'
 #' @evalRd return_tidy(regression = TRUE)
 #' 
-#' @examplesIf rlang::is_installed("gmm")
+#' @examplesIf rlang::is_installed(c("gmm", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(gmm)

--- a/R/hmisc-tidiers.R
+++ b/R/hmisc-tidiers.R
@@ -21,7 +21,7 @@
 #'   `cor(B, A)`. Only one of these pairs will ever be present in the tidy
 #'   output.
 #' 
-#' @examplesIf rlang::is_installed("Hmisc")
+#' @examplesIf rlang::is_installed(c("Hmisc", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(Hmisc)

--- a/R/ks-tidiers.R
+++ b/R/ks-tidiers.R
@@ -10,7 +10,7 @@
 #'   \code{tidyr::pivot_wider(..., names_from = variable, values_from = value)}
 #'   on the output to return to a wide format.
 #' 
-#' @examplesIf rlang::is_installed("ks")
+#' @examplesIf rlang::is_installed(c("ks", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(ks)

--- a/R/list-svd-tidiers.R
+++ b/R/list-svd-tidiers.R
@@ -4,7 +4,7 @@
 #' @inherit tidy.prcomp return details params
 #' @param x A list with components `u`, `d`, `v` returned by [base::svd()].
 #'
-#' @examplesIf rlang::is_installed("modeldata")
+#' @examplesIf rlang::is_installed(c("modeldata", "ggplot2"))
 #'
 #' library(modeldata)
 #' data(hpc_data)

--- a/R/lmodel2-tidiers.R
+++ b/R/lmodel2-tidiers.R
@@ -23,7 +23,7 @@
 #'   be valid. More information can be found in
 #'   `vignette("mod2user", package = "lmodel2")`.
 #'
-#' @examplesIf rlang::is_installed("lmodel2")
+#' @examplesIf rlang::is_installed(c("lmodel2", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(lmodel2)

--- a/R/maps-tidiers.R
+++ b/R/maps-tidiers.R
@@ -12,7 +12,7 @@
 #'     and depend on the inputted map object. See ?maps::map for more information."
 #' )
 #'
-#' @examplesIf rlang::is_installed("maps")
+#' @examplesIf rlang::is_installed(c("maps", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(maps)

--- a/R/mass-ridgelm-tidiers.R
+++ b/R/mass-ridgelm-tidiers.R
@@ -9,7 +9,7 @@
 #'   scale = "Scaling factor of estimated coefficient"
 #' )
 #'
-#' @examplesIf rlang::is_installed("MASS")
+#' @examplesIf rlang::is_installed(c("MASS", "ggplot2"))
 #' 
 #' # load libraries for models and data
 #' library(MASS)

--- a/R/multcomp-tidiers.R
+++ b/R/multcomp-tidiers.R
@@ -7,7 +7,7 @@
 #'
 #' @evalRd return_tidy("contrast", "null.value", "estimate")
 #'
-#' @examplesIf rlang::is_installed("multcomp")
+#' @examplesIf rlang::is_installed(c("multcomp", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(multcomp)

--- a/R/polca-tidiers.R
+++ b/R/polca-tidiers.R
@@ -12,7 +12,7 @@
 #'   "std.error"
 #' )
 #'
-#' @examplesIf rlang::is_installed("poLCA")
+#' @examplesIf rlang::is_installed(c("poLCA", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(poLCA)

--- a/R/psych-tidiers.R
+++ b/R/psych-tidiers.R
@@ -15,7 +15,7 @@
 #'   cannot be set in `tidy`. Instead you must set the `alpha` argument
 #'   to [psych::cohen.kappa()] when creating the `kappa` object.
 #'
-#' @examplesIf rlang::is_installed("psych")
+#' @examplesIf rlang::is_installed(c("psych", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(psych)

--- a/R/stats-decompose-tidiers.R
+++ b/R/stats-decompose-tidiers.R
@@ -15,7 +15,7 @@
 #'   \item{`.seasadj`}{The seasonally adjusted (or "deseasonalised")
 #'     series.}
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' # time series of temperatures in Nottingham, 1920-1939:
 #' nottem

--- a/R/stats-htest-tidiers.R
+++ b/R/stats-htest-tidiers.R
@@ -226,7 +226,7 @@ tidy.pairwise.htest <- function(x, ...) {
 #'
 #' @evalRd return_tidy("n", "delta", "sd", "sig.level", "power")
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' ptt <- power.t.test(n = 2:30, delta = 1)
 #' tidy(ptt)

--- a/R/stats-lm-tidiers.R
+++ b/R/stats-lm-tidiers.R
@@ -11,7 +11,7 @@
 #' @details If the linear model is an `mlm` object (multiple linear model),
 #'   there is an additional column `response`. See [tidy.mlm()].
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' library(ggplot2)
 #' library(dplyr)

--- a/R/stats-nls-tidiers.R
+++ b/R/stats-nls-tidiers.R
@@ -7,7 +7,7 @@
 #'
 #' @evalRd return_tidy(regression = TRUE)
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' # fit model
 #' n <- nls(mpg ~ k * e^wt, data = mtcars, start = list(k = 1, e = 2))

--- a/R/stats-prcomp-tidiers.R
+++ b/R/stats-prcomp-tidiers.R
@@ -54,7 +54,7 @@
 #'   for information on how to interpret the various tidied matrices. Note
 #'   that SVD is only equivalent to PCA on centered data.
 #'
-#' @examplesIf rlang::is_installed("maps")
+#' @examplesIf rlang::is_installed(c("maps", "ggplot2"))
 #' 
 #' pc <- prcomp(USArrests, scale = TRUE)
 #'

--- a/R/stats-smooth.spline-tidiers.R
+++ b/R/stats-smooth.spline-tidiers.R
@@ -5,7 +5,7 @@
 #' @template param_data
 #' @template param_unused_dots
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' # fit model
 #' spl <- smooth.spline(mtcars$wt, mtcars$mpg, df = 4)

--- a/R/stats-time-series-tidiers.R
+++ b/R/stats-time-series-tidiers.R
@@ -72,7 +72,7 @@ tidy.acf <- function(x, ...) {
 #'
 #' @evalRd return_tidy("freq", "spec")
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #'
 #' spc <- spectrum(lh)
 #' tidy(spc)

--- a/R/survival-cch-tidiers.R
+++ b/R/survival-cch-tidiers.R
@@ -7,7 +7,7 @@
 #'
 #' @evalRd return_tidy(regression = TRUE)
 #'
-#' @examplesIf rlang::is_installed("survival")
+#' @examplesIf rlang::is_installed(c("survival", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(survival)

--- a/R/survival-coxph-tidiers.R
+++ b/R/survival-coxph-tidiers.R
@@ -13,7 +13,7 @@
 #'   "p.value"
 #' )
 #'
-#' @examplesIf rlang::is_installed("survival")
+#' @examplesIf rlang::is_installed(c("survival", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(survival)

--- a/R/survival-survfit-tidiers.R
+++ b/R/survival-survfit-tidiers.R
@@ -18,7 +18,7 @@
 #'   strata = "strata if stratified survfit object input"
 #' )
 #'
-#' @examplesIf rlang::is_installed("survival")
+#' @examplesIf rlang::is_installed(c("survival", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(survival)

--- a/R/survival-survreg-tidiers.R
+++ b/R/survival-survreg-tidiers.R
@@ -7,7 +7,7 @@
 #'
 #' @evalRd return_tidy(regression = TRUE)
 #'
-#' @examplesIf rlang::is_installed("survival")
+#' @examplesIf rlang::is_installed(c("survival", "ggplot2"))
 #' 
 #' # load libraries for models and data
 #' library(survival)

--- a/R/zoo-tidiers.R
+++ b/R/zoo-tidiers.R
@@ -6,7 +6,7 @@
 #'
 #' @evalRd return_tidy("index", "series", "value")
 #'
-#' @examplesIf rlang::is_installed("zoo")
+#' @examplesIf rlang::is_installed(c("zoo", "ggplot2"))
 #'
 #' # load libraries for models and data
 #' library(zoo)

--- a/man/augment.coxph.Rd
+++ b/man/augment.coxph.Rd
@@ -104,7 +104,7 @@ is not provided to \code{\link[=augment]{augment()}} and \code{na.action = "na.e
 warning is raised and the incomplete rows are dropped.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/augment.decomposed.ts.Rd
+++ b/man/augment.decomposed.ts.Rd
@@ -77,6 +77,7 @@ We are in the process of defining behaviors for models fit with various
 missing at this time.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # time series of temperatures in Nottingham, 1920-1939:
 nottem
@@ -127,6 +128,7 @@ ggplot(decomps) +
     group = decomp
   ))
   
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[stats:decompose]{stats::decompose()}}

--- a/man/augment.lm.Rd
+++ b/man/augment.lm.Rd
@@ -108,6 +108,7 @@ When \code{newdata} is supplied, only returns \code{.fitted}, \code{.resid} and
 \code{.se.fit} columns.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(ggplot2)
 library(dplyr)
@@ -181,7 +182,7 @@ b <- a + rnorm(length(a))
 result <- lm(b ~ a)
 
 tidy(result)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \link[stats:na.action]{stats::na.action}

--- a/man/augment.nlrq.Rd
+++ b/man/augment.nlrq.Rd
@@ -44,6 +44,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # fit model
 n <- nls(mpg ~ k * e^wt, data = mtcars, start = list(k = 1, e = 2))
@@ -63,7 +64,7 @@ newdata <- head(mtcars)
 newdata$wt <- newdata$wt + 1
 
 augment(n, newdata = newdata)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[quantreg:nlrq]{quantreg::nlrq()}}

--- a/man/augment.nls.Rd
+++ b/man/augment.nls.Rd
@@ -81,6 +81,7 @@ augment.nls does not currently support confidence intervals due to
 a lack of support in stats::predict.nls().
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # fit model
 n <- nls(mpg ~ k * e^wt, data = mtcars, start = list(k = 1, e = 2))
@@ -100,7 +101,7 @@ newdata <- head(mtcars)
 newdata$wt <- newdata$wt + 1
 
 augment(n, newdata = newdata)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \link{tidy}, \code{\link[stats:nls]{stats::nls()}}, \code{\link[stats:predict.nls]{stats::predict.nls()}}

--- a/man/augment.pam.Rd
+++ b/man/augment.pam.Rd
@@ -72,7 +72,7 @@ We are in the process of defining behaviors for models fit with various
 missing at this time.
 }
 \examples{
-\dontshow{if ((rlang::is_installed("cluster") & rlang::is_installed("modeldata") && identical(Sys.getenv("NOT_CRAN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if ((rlang::is_installed(c("cluster", "modeldata", "ggplot2")) && identical(Sys.getenv("NOT_CRAN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(dplyr)

--- a/man/augment.poLCA.Rd
+++ b/man/augment.poLCA.Rd
@@ -83,7 +83,7 @@ modal class) can be found in the \code{posterior} element, these are not
 included in the augmented output.
 }
 \examples{
-\dontshow{if (rlang::is_installed("poLCA")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("poLCA", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(poLCA)

--- a/man/augment.smooth.spline.Rd
+++ b/man/augment.smooth.spline.Rd
@@ -40,6 +40,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # fit model
 spl <- smooth.spline(mtcars$wt, mtcars$mpg, df = 4)
@@ -55,6 +56,7 @@ ggplot(augment(spl, mtcars), aes(wt, mpg)) +
   geom_point() +
   geom_line(aes(y = .fitted))
   
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[stats:smooth.spline]{stats::smooth.spline()}},

--- a/man/augment.survreg.Rd
+++ b/man/augment.survreg.Rd
@@ -94,7 +94,7 @@ We are in the process of defining behaviors for models fit with various
 missing at this time.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/data.frame_tidiers.Rd
+++ b/man/data.frame_tidiers.Rd
@@ -68,6 +68,7 @@ the number of rows and columns. Note that \code{augment.data.frame} will
 throw an error.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 td <- tidy(mtcars)
 td
@@ -79,7 +80,7 @@ library(ggplot2)
 ggplot(td, aes(mean, sd)) + geom_point() +
      geom_text(aes(label = column), hjust = 1, vjust = 1) +
      scale_x_log10() + scale_y_log10() + geom_abline()
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 Other deprecated: 

--- a/man/glance.binDesign.Rd
+++ b/man/glance.binDesign.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("binGroup")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("binGroup", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(binGroup)

--- a/man/glance.cch.Rd
+++ b/man/glance.cch.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/glance.coxph.Rd
+++ b/man/glance.coxph.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/glance.cv.glmnet.Rd
+++ b/man/glance.cv.glmnet.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("glmnet")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("glmnet", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(glmnet)

--- a/man/glance.glmnet.Rd
+++ b/man/glance.glmnet.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("glmnet")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("glmnet", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(glmnet)

--- a/man/glance.gmm.Rd
+++ b/man/glance.gmm.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("gmm")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("gmm", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(gmm)

--- a/man/glance.lm.Rd
+++ b/man/glance.lm.Rd
@@ -43,6 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(ggplot2)
 library(dplyr)
@@ -116,7 +117,7 @@ b <- a + rnorm(length(a))
 result <- lm(b ~ a)
 
 tidy(result)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=glance]{glance()}}, \code{\link[=glance.summary.lm]{glance.summary.lm()}}

--- a/man/glance.lmodel2.Rd
+++ b/man/glance.lmodel2.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("lmodel2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("lmodel2", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(lmodel2)

--- a/man/glance.nls.Rd
+++ b/man/glance.nls.Rd
@@ -43,6 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # fit model
 n <- nls(mpg ~ k * e^wt, data = mtcars, start = list(k = 1, e = 2))
@@ -62,7 +63,7 @@ newdata <- head(mtcars)
 newdata$wt <- newdata$wt + 1
 
 augment(n, newdata = newdata)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \link{tidy}, \code{\link[stats:nls]{stats::nls()}}

--- a/man/glance.pam.Rd
+++ b/man/glance.pam.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if ((rlang::is_installed("cluster") & rlang::is_installed("modeldata") && identical(Sys.getenv("NOT_CRAN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if ((rlang::is_installed(c("cluster", "modeldata", "ggplot2")) && identical(Sys.getenv("NOT_CRAN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(dplyr)

--- a/man/glance.poLCA.Rd
+++ b/man/glance.poLCA.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("poLCA")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("poLCA", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(poLCA)

--- a/man/glance.ridgelm.Rd
+++ b/man/glance.ridgelm.Rd
@@ -47,7 +47,7 @@ This is similar to the output of \code{select.ridgelm}, but it is
 returned rather than printed.
 }
 \examples{
-\dontshow{if (rlang::is_installed("MASS")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("MASS", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(MASS)

--- a/man/glance.smooth.spline.Rd
+++ b/man/glance.smooth.spline.Rd
@@ -31,6 +31,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # fit model
 spl <- smooth.spline(mtcars$wt, mtcars$mpg, df = 4)
@@ -46,6 +47,7 @@ ggplot(augment(spl, mtcars), aes(wt, mpg)) +
   geom_point() +
   geom_line(aes(y = .fitted))
   
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=augment]{augment()}}, \code{\link[stats:smooth.spline]{stats::smooth.spline()}}

--- a/man/glance.summary.lm.Rd
+++ b/man/glance.summary.lm.Rd
@@ -50,6 +50,7 @@ however, that this method does not return all of the columns of the
 non-summary method (e.g. AIC and BIC will be missing.)
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(ggplot2)
 library(dplyr)
@@ -123,7 +124,7 @@ b <- a + rnorm(length(a))
 result <- lm(b ~ a)
 
 tidy(result)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=glance]{glance()}}, \code{\link[=glance.summary.lm]{glance.summary.lm()}}

--- a/man/glance.survfit.Rd
+++ b/man/glance.survfit.Rd
@@ -33,7 +33,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/glance.survreg.Rd
+++ b/man/glance.survreg.Rd
@@ -43,7 +43,7 @@ that no longer have a well-defined value are filled in with an \code{NA}
 of the appropriate type.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/tidy.binDesign.Rd
+++ b/man/tidy.binDesign.Rd
@@ -32,8 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-
-if (requireNamespace("binGroup", quietly = TRUE)) {
+\dontshow{if (rlang::is_installed(c("binGroup", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(binGroup)
 des <- binDesign(
@@ -49,8 +48,7 @@ library(ggplot2)
 ggplot(tidy(des), aes(n, power)) +
   geom_line()
   
-}
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=tidy]{tidy()}}, \code{\link[binGroup:binDesign]{binGroup::binDesign()}}

--- a/man/tidy.cch.Rd
+++ b/man/tidy.cch.Rd
@@ -34,7 +34,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/tidy.cld.Rd
+++ b/man/tidy.cld.Rd
@@ -32,7 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("multcomp")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("multcomp", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(multcomp)

--- a/man/tidy.confint.glht.Rd
+++ b/man/tidy.confint.glht.Rd
@@ -33,7 +33,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("multcomp")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("multcomp", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(multcomp)

--- a/man/tidy.coxph.Rd
+++ b/man/tidy.coxph.Rd
@@ -44,7 +44,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/tidy.cv.glmnet.Rd
+++ b/man/tidy.cv.glmnet.Rd
@@ -31,7 +31,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("glmnet")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("glmnet", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(glmnet)

--- a/man/tidy.emmGrid.Rd
+++ b/man/tidy.emmGrid.Rd
@@ -37,7 +37,7 @@ There are a large number of arguments that can be
 passed on to \code{\link[emmeans:summary.emmGrid]{emmeans::summary.emmGrid()}} or \code{\link[lsmeans:ref.grid]{lsmeans::summary.ref.grid()}}.
 }
 \examples{
-\dontshow{if (rlang::is_installed("emmeans")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("emmeans", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(emmeans)

--- a/man/tidy.glht.Rd
+++ b/man/tidy.glht.Rd
@@ -39,7 +39,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("multcomp")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("multcomp", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(multcomp)

--- a/man/tidy.glmnet.Rd
+++ b/man/tidy.glmnet.Rd
@@ -46,7 +46,7 @@ logical. Furthermore, predictions make sense only with a specific
 choice of lambda.
 }
 \examples{
-\dontshow{if (rlang::is_installed("glmnet")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("glmnet", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(glmnet)

--- a/man/tidy.gmm.Rd
+++ b/man/tidy.gmm.Rd
@@ -44,7 +44,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("gmm")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("gmm", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(gmm)

--- a/man/tidy.kappa.Rd
+++ b/man/tidy.kappa.Rd
@@ -38,7 +38,7 @@ cannot be set in \code{tidy}. Instead you must set the \code{alpha} argument
 to \code{\link[psych:kappa]{psych::cohen.kappa()}} when creating the \code{kappa} object.
 }
 \examples{
-\dontshow{if (rlang::is_installed("psych")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("psych", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(psych)

--- a/man/tidy.kde.Rd
+++ b/man/tidy.kde.Rd
@@ -38,7 +38,7 @@ Returns a data frame in long format with four columns. Use
 on the output to return to a wide format.
 }
 \examples{
-\dontshow{if (rlang::is_installed("ks")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("ks", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(ks)

--- a/man/tidy.lm.Rd
+++ b/man/tidy.lm.Rd
@@ -48,6 +48,7 @@ If the linear model is an \code{mlm} object (multiple linear model),
 there is an additional column \code{response}. See \code{\link[=tidy.mlm]{tidy.mlm()}}.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(ggplot2)
 library(dplyr)
@@ -121,7 +122,7 @@ b <- a + rnorm(length(a))
 result <- lm(b ~ a)
 
 tidy(result)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=tidy]{tidy()}}, \code{\link[stats:summary.lm]{stats::summary.lm()}}

--- a/man/tidy.lmodel2.Rd
+++ b/man/tidy.lmodel2.Rd
@@ -43,7 +43,7 @@ be valid. More information can be found in
 \code{vignette("mod2user", package = "lmodel2")}.
 }
 \examples{
-\dontshow{if (rlang::is_installed("lmodel2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("lmodel2", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(lmodel2)

--- a/man/tidy.lsmobj.Rd
+++ b/man/tidy.lsmobj.Rd
@@ -38,7 +38,7 @@ There are a large number of arguments that can be
 passed on to \code{\link[emmeans:summary.emmGrid]{emmeans::summary.emmGrid()}} or \code{\link[lsmeans:ref.grid]{lsmeans::summary.ref.grid()}}.
 }
 \examples{
-\dontshow{if (rlang::is_installed("emmeans")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("emmeans", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(emmeans)

--- a/man/tidy.map.Rd
+++ b/man/tidy.map.Rd
@@ -32,7 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("maps")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("maps", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(maps)

--- a/man/tidy.nls.Rd
+++ b/man/tidy.nls.Rd
@@ -39,6 +39,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # fit model
 n <- nls(mpg ~ k * e^wt, data = mtcars, start = list(k = 1, e = 2))
@@ -58,7 +59,7 @@ newdata <- head(mtcars)
 newdata$wt <- newdata$wt + 1
 
 augment(n, newdata = newdata)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \link{tidy}, \code{\link[stats:nls]{stats::nls()}}, \code{\link[stats:summary.nls]{stats::summary.nls()}}

--- a/man/tidy.pam.Rd
+++ b/man/tidy.pam.Rd
@@ -38,7 +38,7 @@ specify which components to return.
 For examples, see the pam vignette.
 }
 \examples{
-\dontshow{if ((rlang::is_installed("cluster") & rlang::is_installed("modeldata") && identical(Sys.getenv("NOT_CRAN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if ((rlang::is_installed(c("cluster", "modeldata", "ggplot2")) && identical(Sys.getenv("NOT_CRAN"), "true"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(dplyr)

--- a/man/tidy.poLCA.Rd
+++ b/man/tidy.poLCA.Rd
@@ -32,7 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("poLCA")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("poLCA", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(poLCA)

--- a/man/tidy.power.htest.Rd
+++ b/man/tidy.power.htest.Rd
@@ -32,6 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 ptt <- power.t.test(n = 2:30, delta = 1)
 tidy(ptt)
@@ -40,6 +41,7 @@ library(ggplot2)
 
 ggplot(tidy(ptt), aes(n, power)) +
   geom_line()
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[stats:power.t.test]{stats::power.t.test()}}

--- a/man/tidy.prcomp.Rd
+++ b/man/tidy.prcomp.Rd
@@ -83,7 +83,7 @@ for information on how to interpret the various tidied matrices. Note
 that SVD is only equivalent to PCA on centered data.
 }
 \examples{
-\dontshow{if (rlang::is_installed("maps")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("maps", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 pc <- prcomp(USArrests, scale = TRUE)
 

--- a/man/tidy.rcorr.Rd
+++ b/man/tidy.rcorr.Rd
@@ -44,7 +44,7 @@ matrix from \code{rcorr} there may be entries for both the \code{cor(A, B)} and
 output.
 }
 \examples{
-\dontshow{if (rlang::is_installed("Hmisc")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("Hmisc", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(Hmisc)

--- a/man/tidy.ref.grid.Rd
+++ b/man/tidy.ref.grid.Rd
@@ -37,7 +37,7 @@ There are a large number of arguments that can be
 passed on to \code{\link[emmeans:summary.emmGrid]{emmeans::summary.emmGrid()}} or \code{\link[lsmeans:ref.grid]{lsmeans::summary.ref.grid()}}.
 }
 \examples{
-\dontshow{if (rlang::is_installed("emmeans")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("emmeans", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(emmeans)

--- a/man/tidy.ridgelm.Rd
+++ b/man/tidy.ridgelm.Rd
@@ -32,7 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("MASS")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("MASS", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(MASS)

--- a/man/tidy.roc.Rd
+++ b/man/tidy.roc.Rd
@@ -33,7 +33,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("AUC")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("AUC", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(AUC)

--- a/man/tidy.spec.Rd
+++ b/man/tidy.spec.Rd
@@ -31,6 +31,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 spc <- spectrum(lh)
 tidy(spc)
@@ -38,6 +39,7 @@ tidy(spc)
 library(ggplot2)
 ggplot(tidy(spc), aes(freq, spec)) +
   geom_line()
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=tidy]{tidy()}}, \code{\link[stats:spectrum]{stats::spectrum()}}

--- a/man/tidy.summary.glht.Rd
+++ b/man/tidy.summary.glht.Rd
@@ -33,7 +33,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("multcomp")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("multcomp", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(multcomp)

--- a/man/tidy.summary_emm.Rd
+++ b/man/tidy.summary_emm.Rd
@@ -32,7 +32,7 @@ There are a large number of arguments that can be
 passed on to \code{\link[emmeans:summary.emmGrid]{emmeans::summary.emmGrid()}} or \code{\link[lsmeans:ref.grid]{lsmeans::summary.ref.grid()}}.
 }
 \examples{
-\dontshow{if (rlang::is_installed("emmeans")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("emmeans", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(emmeans)

--- a/man/tidy.survfit.Rd
+++ b/man/tidy.survfit.Rd
@@ -32,7 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/tidy.survreg.Rd
+++ b/man/tidy.survreg.Rd
@@ -39,7 +39,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("survival", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(survival)

--- a/man/tidy.zoo.Rd
+++ b/man/tidy.zoo.Rd
@@ -32,7 +32,7 @@ If a model has several distinct types of components, you will need to
 specify which components to return.
 }
 \examples{
-\dontshow{if (rlang::is_installed("zoo")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("zoo", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 # load libraries for models and data
 library(zoo)

--- a/man/tidy_irlba.Rd
+++ b/man/tidy_irlba.Rd
@@ -76,7 +76,7 @@ If no appropriate tidying method is found, they throw an error.
 A very thin wrapper around \code{\link[=tidy_svd]{tidy_svd()}}.
 }
 \examples{
-\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("modeldata", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(modeldata)
 data(hpc_data)

--- a/man/tidy_svd.Rd
+++ b/man/tidy_svd.Rd
@@ -89,7 +89,7 @@ for information on how to interpret the various tidied matrices. Note
 that SVD is only equivalent to PCA on centered data.
 }
 \examples{
-\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (rlang::is_installed(c("modeldata", "ggplot2"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(modeldata)
 data(hpc_data)

--- a/vignettes/broom_and_dplyr.Rmd
+++ b/vignettes/broom_and_dplyr.Rmd
@@ -10,6 +10,16 @@ vignette: >
 
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(message = FALSE, warning = FALSE)
+
+if (rlang::is_installed("ggplot2")) {
+  run <- TRUE
+} else {
+  run <- FALSE
+}
+
+knitr::opts_chunk$set(
+  eval = run
+)
 ```
 
 # broom and dplyr


### PR DESCRIPTION
I may be missing something, but it seems that ggplot2 is only used in documentation, and does not need to be listed in `Imports`. In this PR, I've moved ggplot2 to `Suggests`.

(I was doing some dependency reduction on my own packages, and was wondering how ggplot2 made it into my dependency list.)
