### PR TITLE
Fix typo in 'examplesIf'

### DIFF
--- a/R/btergm-tidiers.R
+++ b/R/btergm-tidiers.R
@@ -16,7 +16,7 @@
 #' @export
 #' @aliases btergm_tidiers
 #' @seealso [tidy()], [btergm::btergm()]
-#' @examplesIf (rlang::is_installed("bbmle") & rlang::is_installed("network"))
+#' @examplesIf (rlang::is_installed("btergm") & rlang::is_installed("network"))
 #' 
 #' library(btergm)
 #' library(network)

--- a/man/tidy.btergm.Rd
+++ b/man/tidy.btergm.Rd
@@ -44,7 +44,7 @@ temporal exponential random graph model estimated with the \pkg{xergm}.
 It simply returns the coefficients and their confidence intervals.
 }
 \examples{
-\dontshow{if ((rlang::is_installed("bbmle") & rlang::is_installed("network"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if ((rlang::is_installed("btergm") & rlang::is_installed("network"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 
 library(btergm)
 library(network)


### PR DESCRIPTION
Or at least, I assume it's a typo, given the `library(btergm)` in the next line.