### PR TITLE
Fixed survexp test to no longer use ratetable function

### DIFF
--- a/tests/testthat/test-survival-survdiff.R
+++ b/tests/testthat/test-survival-survdiff.R
@@ -15,15 +15,13 @@ fit3 <- survdiff(
   data = lung
 )
 
-expect <- survexp(
-  futime ~ ratetable(
-    age = (accept.dt - birth.dt),
-    sex = 1,
-    year = accept.dt,
-    race = "white"
-  ),
-  jasa,
-  cohort = FALSE, ratetable = survexp.usr
+expect <- survexp(futime ~ 1,
+                  rmap = list(age = (accept.dt - birth.dt),
+                              sex = 1,
+                              year = accept.dt,
+                              race = "white"),
+                  jasa,
+                  cohort = FALSE, ratetable = survexp.usr
 )
 
 fit4 <- survdiff(Surv(jasa$futime, jasa$fustat) ~ offset(expect))


### PR DESCRIPTION
I received an email from Dr. Therneau, who maintains the survival package:

> One of the test files in broom uses a call to survexp that is out of date, and as of the next release of the package will no longer be supported.    Essentially, you have a very old copy of an example in survexp.Rd.    I've attached an updated file, to make it easier to update.   (Per my mercurial logs, I think it changed in 2018).

The change is his (but works for me locally)