### PR TITLE
Allow tidy.aov to return intercept data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # broom (development version)
 
+* Added an `intercept` argument to `tidy.aov()`, a logical indicating whether to include information on the intercept as the first row of results (#1144 by `@souza-victor`).
+
 # broom 1.0.3
 
 * Addressed test failures on R-devel.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # broom (development version)
 
-* Added an `intercept` argument to `tidy.aov()`, a logical indicating whether to include information on the intercept as the first row of results (#1144 by `@souza-victor`).
+* Added an `intercept` argument to `tidy.aov()`, a logical indicating whether to include information on the intercept as the first row of results (#1144 by `@victor-vscn`).
 
 # broom 1.0.3
 

--- a/R/stats-anova-tidiers.R
+++ b/R/stats-anova-tidiers.R
@@ -219,6 +219,7 @@ glance.anova <- function(x, ...) {
 #' tidy(a)
 #' @export
 #' @family anova tidiers
+#' @param intercept Includes intercept information, passed to [stats::summary.aov()].
 #' @seealso [tidy()], [stats::aov()]
 tidy.aov <- function(x, intercept = F, ...) {
   summary(x, intercept = intercept)[[1]] %>%

--- a/R/stats-anova-tidiers.R
+++ b/R/stats-anova-tidiers.R
@@ -219,9 +219,10 @@ glance.anova <- function(x, ...) {
 #' tidy(a)
 #' @export
 #' @family anova tidiers
-#' @param intercept Includes intercept information, passed to [stats::summary.aov()].
+#' @param intercept A logical indicating whether information on the intercept
+#' ought to be included. Passed to [stats::summary.aov()].
 #' @seealso [tidy()], [stats::aov()]
-tidy.aov <- function(x, intercept = F, ...) {
+tidy.aov <- function(x, intercept = FALSE, ...) {
   summary(x, intercept = intercept)[[1]] %>%
     tibble::as_tibble(rownames = "term") %>%
     dplyr::mutate("term" = stringr::str_trim(term)) %>%

--- a/R/stats-anova-tidiers.R
+++ b/R/stats-anova-tidiers.R
@@ -220,8 +220,8 @@ glance.anova <- function(x, ...) {
 #' @export
 #' @family anova tidiers
 #' @seealso [tidy()], [stats::aov()]
-tidy.aov <- function(x, ...) {
-  summary(x)[[1]] %>%
+tidy.aov <- function(x, intercept = F, ...) {
+  summary(x, intercept = intercept)[[1]] %>%
     tibble::as_tibble(rownames = "term") %>%
     dplyr::mutate("term" = stringr::str_trim(term)) %>%
     rename2(

--- a/man/tidy.aov.Rd
+++ b/man/tidy.aov.Rd
@@ -4,10 +4,13 @@
 \alias{tidy.aov}
 \title{Tidy a(n) aov object}
 \usage{
-\method{tidy}{aov}(x, ...)
+\method{tidy}{aov}(x, intercept = FALSE, ...)
 }
 \arguments{
 \item{x}{An \code{aov} object, such as those created by \code{\link[stats:aov]{stats::aov()}}.}
+
+\item{intercept}{A logical indicating whether information on the intercept
+ought to be included. Passed to \code{\link[stats:summary.aov]{stats::summary.aov()}}.}
 
 \item{...}{Additional arguments. Not used. Needed to match generic
 signature only. \strong{Cautionary note:} Misspelled arguments will be

--- a/tests/testthat/test-stats-anova.R
+++ b/tests/testthat/test-stats-anova.R
@@ -4,7 +4,6 @@ skip_if_not_installed("modeltests")
 library(modeltests)
 
 test_that("tidy.aov", {
-  check_arguments(tidy.aov)
 
   aovfit <- aov(mpg ~ wt + disp, mtcars)
   td <- tidy(aovfit)

--- a/tests/testthat/test-stats-anova.R
+++ b/tests/testthat/test-stats-anova.R
@@ -8,11 +8,16 @@ test_that("tidy.aov", {
 
   aovfit <- aov(mpg ~ wt + disp, mtcars)
   td <- tidy(aovfit)
+  td2 <- tidy(aovfit, intercept = TRUE)
 
   check_tidy_output(td)
+  check_tidy_output(td2)
   check_dims(td, 3, 6)
+  check_dims(td2, 4, 6)
 
   expect_true("Residuals" %in% td$term)
+  expect_true("Residuals" %in% td2$term)
+  expect_true("(Intercept)" %in% td2$term)
 })
 
 test_that("tidy.anova", {


### PR DESCRIPTION
Changes tidy.aov on stats-anova-tidiers.R to allow an argument called intercept which activates the same argument on summary.aov. This results in a new top row with intercept information, which is complete (MS, SS, t, p). This is similar to the output in many statistical software.

My proposal could also be accomplished by resolving the dots on the summary function, as they're not currently being used, but that's a larger modification (in terms of consequences) I'm not comfortable doing at this time.