### PR TITLE
Make id column names agnostic in augment.mlogit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Removed speedglm as a Suggested package following the package's removal from CRAN. If the package has not made it to CRAN by the next release, the tidiers for those objects will be hard-deprecated.
 
+* Addressed bug in mlogit tidiers where `augment.mlogit()` would fail if supplied a model fitted with a non-default `dfidx()`. (#1156 by `@gregmacfarlane`)
+
 # broom 1.0.4
 
 * Added an `intercept` argument to `tidy.aov()`, a logical indicating whether to include information on the intercept as the first row of results (#1144 by `@victor-vscn`).

--- a/R/mlogit-tidiers.R
+++ b/R/mlogit-tidiers.R
@@ -84,8 +84,8 @@ augment.mlogit <- function(x, data = x$model, ...) {
     ) %>%
     # reappend the id columns
     dplyr::mutate(
-      id = idx$id1,
-      alternative = idx$id2,
+      id = idx[, 1],
+      alternative = idx[, 2],
       .resid = as.vector(x$residuals)
     ) %>%
     dplyr::select(id, alternative, chosen, everything())

--- a/tests/testthat/test-mlogit.R
+++ b/tests/testthat/test-mlogit.R
@@ -1,0 +1,61 @@
+context("mlogit")
+
+skip_on_cran()
+
+skip_if_not_installed("modeltests")
+library(modeltests)
+
+skip_if_not_installed("mlogit")
+skip_if_not_installed("AER")
+library(mlogit)
+library(AER)
+library(dplyr)
+
+data("Fishing", package = "mlogit")
+Fish <- dfidx(Fishing, varying = 2:9, shape = "wide", choice = "mode")
+fit1 <- mlogit(mode ~ price + catch, data = Fish)
+
+data("TravelMode", package = "AER")
+fit2 <- mlogit(choice ~ wait + travel + vcost, TravelMode, heterosc = TRUE)
+
+test_that("mlogit tidier arguments", {
+  check_arguments(tidy.mlogit)
+  check_arguments(glance.mlogit)
+  check_arguments(augment.mlogit, strict = FALSE)
+})
+
+test_that("tidy.mlogit", {
+  td1 <- tidy(fit1)
+  td2 <- tidy(fit1, conf.int = TRUE)
+  td3 <- tidy(fit2)
+  td4 <- tidy(fit2, conf.int = TRUE)
+  
+  check_tidy_output(td1)
+  check_tidy_output(td2)
+  check_tidy_output(td3)
+  check_tidy_output(td4)
+})
+
+test_that("glance.mlogit", {
+  gl1 <- glance(fit1)
+  gl2 <- glance(fit2)
+  
+  check_glance_outputs(gl1)
+  check_glance_outputs(gl2)
+})
+
+test_that("augment.mlogit", {
+  check_augment_function(
+    aug = augment.mlogit,
+    model = fit1,
+    data = Fish,
+    newdata = Fish,
+    strict = FALSE
+  )
+  
+  au1 <- augment(fit1)
+  au2 <- augment(fit2)
+  
+  expect_true(all(c("id", "alternative", "chosen", ".resid", ".fitted") %in% names(au1)))
+  expect_true(all(c("id", "alternative", "chosen", ".resid", ".fitted") %in% names(au2)))
+})


### PR DESCRIPTION
This fixes an issue where mlogit can give different names to the id columns in the estimation dataset.