### PR TITLE
Return correct standard errors in `tidy.survfit()`

### DIFF
--- a/R/survival-survfit-tidiers.R
+++ b/R/survival-survfit-tidiers.R
@@ -58,6 +58,10 @@
 #'
 tidy.survfit <- function(x, ...) {
   if (inherits(x, "survfitms")) {
+    # A survfit object may contain std(log S) or std(S), tidy/summary should
+    # always be std(S).
+    if (!is.null(x$std.err) && x$logse) x$std.err <- x$std.err * x$pstate 
+    
     # c() coerces to vector
     ret <- data.frame(
       time = x$time,
@@ -65,7 +69,7 @@ tidy.survfit <- function(x, ...) {
       n.event = c(x$n.event),
       n.censor = c(x$n.censor),
       estimate = c(x$pstate),
-      std.error = c(summary(x)$std.err),
+      std.error = c(x$std.err),
       conf.high = c(x$upper),
       conf.low = c(x$lower),
       state = rep(x$states, each = nrow(x$pstate))
@@ -73,13 +77,17 @@ tidy.survfit <- function(x, ...) {
 
     ret <- ret[ret$state != "", ]
   } else {
+    # A survfit object may contain std(log S) or std(S), tidy/summary should
+    # always be std(S).
+    if (!is.null(x$std.err) && x$logse) x$std.err <- x$std.err * x$surv 
+    
     ret <- data.frame(
       time = x$time,
       n.risk = x$n.risk,
       n.event = x$n.event,
       n.censor = x$n.censor,
       estimate = x$surv,
-      std.error = summary(x)$std.err,
+      std.error = x$std.err,
       conf.high = x$upper,
       conf.low = x$lower
     )

--- a/R/survival-survfit-tidiers.R
+++ b/R/survival-survfit-tidiers.R
@@ -65,7 +65,9 @@ tidy.survfit <- function(x, ...) {
       n.event = c(x$n.event),
       n.censor = c(x$n.censor),
       estimate = c(x$pstate),
-      std.error = c(summary(x)$std.err),
+      # A survfit object may contain std(log S) or std(S), tidy/summary should
+      # always be std(S).
+      std.error = c(x$std.err * x$surv),
       conf.high = c(x$upper),
       conf.low = c(x$lower),
       state = rep(x$states, each = nrow(x$pstate))
@@ -79,7 +81,9 @@ tidy.survfit <- function(x, ...) {
       n.event = x$n.event,
       n.censor = x$n.censor,
       estimate = x$surv,
-      std.error = summary(x)$std.err,
+      # A survfit object may contain std(log S) or std(S), tidy/summary should
+      # always be std(S).
+      std.error = x$std.err * x$surv,
       conf.high = x$upper,
       conf.low = x$lower
     )

--- a/R/survival-survfit-tidiers.R
+++ b/R/survival-survfit-tidiers.R
@@ -65,7 +65,7 @@ tidy.survfit <- function(x, ...) {
       n.event = c(x$n.event),
       n.censor = c(x$n.censor),
       estimate = c(x$pstate),
-      std.error = c(x$std.err),
+      std.error = c(summary(x)$std.err),
       conf.high = c(x$upper),
       conf.low = c(x$lower),
       state = rep(x$states, each = nrow(x$pstate))
@@ -79,7 +79,7 @@ tidy.survfit <- function(x, ...) {
       n.event = x$n.event,
       n.censor = x$n.censor,
       estimate = x$surv,
-      std.error = x$std.err,
+      std.error = summary(x)$std.err,
       conf.high = x$upper,
       conf.low = x$lower
     )


### PR DESCRIPTION
`tidy.survfit()` currently returns standard errors for the cumulative hazard instead of the survival probability. This PR fixes this so that standard errors for the survival probability are returned. This makes the output consistent with `summary.survfit`.

Here's a [blog post](https://dominicmagirr.github.io/post/2022-01-18-be-careful-with-standard-errors-in-survival-survfit/) covering the sneaky behaviour of standard errors in `survival`. The short version is that `fit$std.err` (which `tidy.survfit()` currently uses) returns the standard errors for the cumulative hazard, whereas `summary(fit)$std.err` returns the standard errors for the survival probabilities.

``` r
library(survival)
library(broom)

fit <- survfit(Surv(time, status) ~ x, data = aml)

# Cumulative hazard
fit$std.err
#>  [1] 0.09534626 0.14213381 0.19508758 0.24873417 0.24873417 0.33446777
#>  [7] 0.44181673 0.44181673 0.83378775 0.83378775 0.12909944 0.20412415
#> [13] 0.24397502 0.24397502 0.30472470 0.37796447 0.47559487 0.62678317
#> [19] 0.94491118        Inf

# Survival probability
summary(fit)$std.err
#>  [1] 0.08667842 0.11629130 0.13966497 0.15263233 0.16419327 0.16266889
#>  [7] 0.15349275 0.10758287 0.13608276 0.14231876 0.14813006 0.14698618
#> [13] 0.13871517 0.12187451 0.09186636        NaN
```

<sup>Created on 2023-06-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

## Edit

After using this on some examples, I think it's better to calculate manually instead of using `summary()`; otherwise you get an error when using survfit objects that have been reformulated with `survfit0()` due to incompatible numbers of rows.

I've updated the PR to use the calculations done in the  survival package instead of `summary()` like in the reprex above.

For reference, here are the relevant line in survival's source code.

`survfit`:

https://github.com/therneau/survival/blob/e8de7b732daa9a82c1ceaad93fd68ee7545c7736/R/survfitms.R#L178

`survfitms`:

https://github.com/therneau/survival/blob/e8de7b732daa9a82c1ceaad93fd68ee7545c7736/R/survfitms.R#L375
