### PR TITLE
Added adj.r.squared and npar as outputs of glance.gam for mgcv::gam

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Moved forward with deprecation of tidiers for objects from the sp package. See resources linked in [tidymodels/broom#1142](https://github.com/tidymodels/broom/issues/1142) for more information on migration from retiring spatial packages.
 
+* Added support for columns `adj.r.squared` and `npar` in `glance()` method for objects outputted from `mgcv::gam()` (#1172).
+
 # broom 1.0.5
 
 * `tidy.coxph()` will now pass its ellipses `...` to `summary()` internally (#1151 by `@ste-tuf`).

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -74,11 +74,11 @@ tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE,
     class(sx) <- c("anova", "data.frame")
     ret <- tidy(sx)
   }
-
+  
   if (exponentiate && parametric) {
     ret <- exponentiate(ret)
   }
-
+  
   ret
 }
 
@@ -94,7 +94,9 @@ tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE,
 #'   "BIC",
 #'   "deviance",
 #'   "df.residual",
-#'   "nobs"
+#'   "nobs",
+#'   "adj.r.squared",
+#'   "npar"
 #' )
 #'
 #'
@@ -102,6 +104,8 @@ tidy.gam <- function(x, parametric = FALSE, conf.int = FALSE,
 #' @family mgcv tidiers
 #' @seealso [glance()], [mgcv::gam()]
 glance.gam <- function(x, ...) {
+  s <- summary(x)
+  
   as_glance_tibble(
     df = sum(x$edf),
     logLik = as.numeric(stats::logLik(x)),
@@ -110,7 +114,13 @@ glance.gam <- function(x, ...) {
     deviance = stats::deviance(x),
     df.residual = stats::df.residual(x),
     nobs = stats::nobs(x),
-    na_types = "irrrrii"
+    # m = s$m, # number of smooth terms (non-standard)
+    adj.r.squared = s$r.sq,
+    # dev.expl = s$dev.expl, # proportion deviance explained (non-standard)
+    # dispersion = s$dispersion, # scale parameter (non-standard)
+    # rank = s$rank, # apparent model rank (non-standard)
+    npar = s$np,
+    na_types = "irrrriiri"
   )
 }
 

--- a/R/mgcv-tidiers.R
+++ b/R/mgcv-tidiers.R
@@ -114,11 +114,7 @@ glance.gam <- function(x, ...) {
     deviance = stats::deviance(x),
     df.residual = stats::df.residual(x),
     nobs = stats::nobs(x),
-    # m = s$m, # number of smooth terms (non-standard)
     adj.r.squared = s$r.sq,
-    # dev.expl = s$dev.expl, # proportion deviance explained (non-standard)
-    # dispersion = s$dispersion, # scale parameter (non-standard)
-    # rank = s$rank, # apparent model rank (non-standard)
     npar = s$np,
     na_types = "irrrriiri"
   )

--- a/man/glance.gam.Rd
+++ b/man/glance.gam.Rd
@@ -67,6 +67,7 @@ Other mgcv tidiers:
 \concept{mgcv tidiers}
 \value{
 A \code{\link[tibble:tibble]{tibble::tibble()}} with exactly one row and columns:
+  \item{adj.r.squared}{Adjusted R squared statistic, which is like the R squared statistic except taking degrees of freedom into account.}
   \item{AIC}{Akaike's Information Criterion for the model.}
   \item{BIC}{Bayesian Information Criterion for the model.}
   \item{deviance}{Deviance of the model.}
@@ -74,5 +75,6 @@ A \code{\link[tibble:tibble]{tibble::tibble()}} with exactly one row and columns
   \item{df.residual}{Residual degrees of freedom.}
   \item{logLik}{The log-likelihood of the model. [stats::logLik()] may be a useful reference.}
   \item{nobs}{Number of observations used.}
+  \item{npar}{Number of parameters in the model.}
 
 }


### PR DESCRIPTION
When using glance.gam for mgcv::gam, I was unpleasantly surprised to not find any results for adjusted R squared. This is one of the most important model evaluation statistics for statistical inference. Not only my colleagues and I, but also probably most other users of glance.gam would need this.

On examining the code, it seems that the only outputs provided by the current glance method are those directly available from the gam model object. But summary.gam provides some additional valuable outputs. So, I have modified the code to calculate the summary(x) on the model object (x) and then add in the other useful outputs (at least, those, that output a scalar numeric output.

That said, when examining modeltests::column_glossary, I could not find most of the additional outputs. So, I have added the only two outputs available in the modeltests::column_glossary (adj.r.squared and npar); for the other outputs, I have listed them in the code but commented them out--that way, if they are supported in the future in modeltests::column_glossary, the code can more easily be updated.

I have tested the updates with the unit tests in tests/testthat/test-mgcv.R; my modifications pass the tests. I hope you can accept this pull request.