### PR TITLE
Pass ellipsis to `summary.betareg()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Corrected confidence interval values for precision components in `tidy.betareg()` output (#1169).
 
+* `tidy.betareg()` will now pass its ellipses `...` to `summary()` internally (#1198 by `@DanChaltiel`). Among other things, this allows choosing the type of residuals.
+
 * Fixed bug in tidier for `car::linearHypothesis()` output with long formulas (#1171).
 
 * Added support for columns `adj.r.squared` and `npar` in `glance()` method for objects outputted from `mgcv::gam()` (#1172).

--- a/R/betareg-tidiers.R
+++ b/R/betareg-tidiers.R
@@ -3,7 +3,8 @@
 #'
 #' @param x A `betareg` object produced by a call to [betareg::betareg()].
 #' @template param_confint
-#' @template param_unused_dots
+#' @param ... For `tidy()`, additional arguments passed to `summary(x, ...)`.
+#' Otherwise ignored.
 #'
 #' @evalRd return_tidy(regression = TRUE,
 #'   component = "Whether a particular term was used to model the mean or the
@@ -46,7 +47,7 @@ tidy.betareg <- function(x, conf.int = FALSE, conf.level = .95, ...) {
   check_ellipses("exponentiate", "tidy", "betareg", ...)
 
   ret <- map_as_tidy_tibble(
-    purrr::map(coef(summary(x)), as.matrix),
+    purrr::map(coef(summary(x, ...)), as.matrix),
     new_names = c("estimate", "std.error", "statistic", "p.value")
   )
 

--- a/tests/testthat/test-betareg.R
+++ b/tests/testthat/test-betareg.R
@@ -32,6 +32,24 @@ test_that("tidy.betareg", {
   )
 
   check_dims(td1, 12, 8)
+  
+  #test passing ellipsis to summary
+  data_test <- structure(
+    list(p = c(0.4238, 0.8248, 0.5927, 0.3208, 0.8317, 
+               0.7314, 0.4624, 0.5224, 0.3528, 0.7739, 0.1264, 0.4516, 0.4306, 
+               0.5243, 0.5117, 0.149, 0.3342, 0.5069, 0.7101, 0.8019, 0.7569, 
+               0.9096, 0.9013, 0.5403, 0.2264, 0.5775, 0.7366, 0.4086, 0.575, 
+               0.6623, 0.7758, 0.1517, 0.7587, 0.3247, 0.7463, 0.6325), 
+         w = structure(c(1L, 2L, 9L, 4L, 3L, 5L, 1L, 9L, 4L, 3L, 5L, 2L, 4L, 5L, 1L, 2L, 9L, 
+                         4L, 3L, 5L, 8L, 7L, 6L, 1L, 2L, 9L, 3L, 5L, 8L, 7L, 1L, 2L, 9L, 
+                         4L, 3L, 5L), 
+                       levels = c("1", "2", "3", "4", "5", "6", "7", "8", "9"), 
+                       class = "factor")), 
+    row.names = c(NA, -36L), class = c("tbl_df", "tbl", "data.frame")
+  )
+  m <- betareg::betareg(p ~ w, data = data_test)
+  expect_warning(tidy(m))
+  expect_silent(tidy(m, type = "sweighted"))
 })
 
 test_that("glance.betareg", {


### PR DESCRIPTION
This PR introduces passing ellipsis to `summary.betareg()`.

This allows choosing the type of residual, as the default one may produce NaN, as explained in detail in #1198.

I'll leave running the documentation to you, as it would require me to install a tremendous amount of packages 😅 