### PR TITLE
Improve numerical precision of several p-value calculations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 * Corrected coefficient values in `tidy.varest()` output (#1174).
 
+* Improved the numerical precision of several p-value calculations.
+
 # broom 1.0.5
 
 * `tidy.coxph()` will now pass its ellipses `...` to `summary()` internally (#1151 by `@ste-tuf`).

--- a/R/joinerml-tidiers.R
+++ b/R/joinerml-tidiers.R
@@ -102,7 +102,7 @@ tidy.mjoint <- function(x, component = "survival", conf.int = FALSE,
   out <- out[, c(5, 1:4)]
 
   if (conf.int) {
-    cv <- qnorm(1 - (1 - conf.level) / 2)
+    cv <- stats::qnorm(1 - (1 - conf.level) / 2)
     out$conf.low <- out$estimate - cv * out$std.error
     out$conf.high <- out$estimate + cv * out$std.error
   }

--- a/R/lfe-tidiers.R
+++ b/R/lfe-tidiers.R
@@ -169,7 +169,7 @@ tidy.felm <- function(x, conf.int = FALSE, conf.level = .95, fe = FALSE, se.type
       rename(estimate = effect, std.error = se) %>%
       select(contains("response"), dplyr::everything()) %>%
       mutate(statistic = estimate / std.error) %>%
-      mutate(p.value = 2 * (1 - stats::pt(statistic, df = N)))
+      mutate(p.value = 2 * (stats::pt(abs(statistic), df = N, lower.tail = FALSE)))
 
     if (conf.int) {
       crit_val_low <- stats::qnorm(1 - (1 - conf.level) / 2)

--- a/R/mediation-tidiers.R
+++ b/R/mediation-tidiers.R
@@ -71,10 +71,10 @@ tidy.mediate <- function(x, conf.int = FALSE, conf.level = .95, ...) {
         3 / 2
       }
       a <- top / under
-      lower.inv <- pnorm(z + (z + qnorm(low)) / (1 - a * (z + qnorm(low))))
-      lower2 <- lower <- quantile(theta, lower.inv)
-      upper.inv <- pnorm(z + (z + qnorm(high)) / (1 - a * (z + qnorm(high))))
-      upper2 <- upper <- quantile(theta, upper.inv)
+      lower.inv <- stats::pnorm(z + (z + stats::qnorm(low)) / (1 - a * (z + stats::qnorm(low))))
+      lower2 <- lower <- stats::quantile(theta, lower.inv)
+      upper.inv <- stats::pnorm(z + (z + stats::qnorm(high)) / (1 - a * (z + stats::qnorm(high))))
+      upper2 <- upper <- stats::quantile(theta, upper.inv)
       return(c(lower, upper))
     }
     ci <- with(
@@ -83,7 +83,7 @@ tidy.mediate <- function(x, conf.int = FALSE, conf.level = .95, ...) {
     )
     if (s$boot.ci.type != "bca") {
       CI <- function(theta) {
-        return(quantile(theta, c(low, high), na.rm = TRUE))
+        return(stats::quantile(theta, c(low, high), na.rm = TRUE))
       }
       ci <- with(
         x,

--- a/R/mfx-tidiers.R
+++ b/R/mfx-tidiers.R
@@ -82,10 +82,10 @@ tidy.mfx <-
       x_tidy <-
         x_tidy %>%
         dplyr::mutate(
-          conf.low = estimate - qt(1 - (1 - conf.level) / 2,
+          conf.low = estimate - stats::qt(1 - (1 - conf.level) / 2,
             df = x$fit$df.residual
           ) * std.error,
-          conf.high = estimate + qt(1 - (1 - conf.level) / 2,
+          conf.high = estimate + stats::qt(1 - (1 - conf.level) / 2,
             df = x$fit$df.residual
           ) * std.error
         )

--- a/R/quantreg-nlrq-tidiers.R
+++ b/R/quantreg-nlrq-tidiers.R
@@ -43,7 +43,7 @@ tidy.nlrq <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   if (conf.int) {
     x_summary <- summary(x)
     a <- (1 - conf.level) / 2
-    cv <- qt(c(a, 1 - a), df = x_summary[["rdf"]])
+    cv <- stats::qt(c(a, 1 - a), df = x_summary[["rdf"]])
     ret[["conf.low"]] <- ret[["estimate"]] + (cv[1] * ret[["std.error"]])
     ret[["conf.high"]] <- ret[["estimate"]] + (cv[2] * ret[["std.error"]])
   }

--- a/R/quantreg-rq-tidiers.R
+++ b/R/quantreg-rq-tidiers.R
@@ -186,7 +186,7 @@ process_rq <- function(rq_obj, se.type = NULL,
   }
   if (conf.int) {
     a <- (1 - conf.level) / 2
-    cv <- qt(c(a, 1 - a), df = rq_obj[["rdf"]])
+    cv <- stats::qt(c(a, 1 - a), df = rq_obj[["rdf"]])
     co[["conf.low"]] <- co[["estimate"]] + (cv[1] * co[["std.error"]])
     co[["conf.high"]] <- co[["estimate"]] + (cv[2] * co[["std.error"]])
   }

--- a/R/spdep-tidiers.R
+++ b/R/spdep-tidiers.R
@@ -77,7 +77,7 @@ tidy.sarlm <- function(x, conf.int = FALSE, conf.level = .95, ...) {
       estimate = as.numeric(s$rho),
       std.error = as.numeric(s$rho.se),
       statistic = as.numeric(estimate / std.error),
-      p.value = as.numeric(2 * (1 - pnorm(abs(statistic))))
+      p.value = as.numeric(2 * (stats::pnorm(abs(statistic), lower.tail = FALSE)))
     )
     ret <- bind_rows(rho, ret)
   }
@@ -89,7 +89,7 @@ tidy.sarlm <- function(x, conf.int = FALSE, conf.level = .95, ...) {
       estimate = as.numeric(s$lambda),
       std.error = as.numeric(s$lambda.se),
       statistic = as.numeric(estimate / std.error),
-      p.value = as.numeric(2 * (1 - pnorm(abs(statistic))))
+      p.value = as.numeric(2 * (stats::pnorm(abs(statistic), lower.tail = FALSE)))
     )
     ret <- bind_rows(ret, lambda)
   }

--- a/R/stats-mlm-tidiers.R
+++ b/R/stats-mlm-tidiers.R
@@ -76,7 +76,7 @@ tidy.mlm <- function(x,
 confint_mlm <- function(object, level = 0.95, ...) {
   coef <- as.numeric(coef(object))
   alpha <- (1 - level) / 2
-  crit_val <- qt(c(alpha, 1 - alpha), object$df.residual)
+  crit_val <- stats::qt(c(alpha, 1 - alpha), object$df.residual)
   se <- sqrt(diag(stats::vcov(object)))
   ci <- as.data.frame(coef + se %o% crit_val)
   colnames(ci) <- c("conf.low", "conf.high")

--- a/R/survival-aareg-tidiers.R
+++ b/R/survival-aareg-tidiers.R
@@ -72,7 +72,7 @@ glance.aareg <- function(x, ...) {
 
   as_glance_tibble(
     statistic = chi,
-    p.value = as.numeric(1 - stats::pchisq(chi, df)),
+    p.value = as.numeric(stats::pchisq(chi, df, lower.tail = FALSE)),
     df = df,
     nobs = stats::nobs(x),
     na_types = "rrii"

--- a/R/survival-survdiff-tidiers.R
+++ b/R/survival-survdiff-tidiers.R
@@ -78,6 +78,6 @@ glance.survdiff <- function(x, ...) {
     statistic = x$chisq,
     df = (sum(1 * (tmp > 0))) - 1
   )
-  rval$p.value <- 1 - stats::pchisq(rval$statistic, rval$df)
+  rval$p.value <- stats::pchisq(rval$statistic, rval$df, lower.tail = FALSE)
   rval
 }

--- a/R/survival-survreg-tidiers.R
+++ b/R/survival-survreg-tidiers.R
@@ -116,7 +116,7 @@ glance.survreg <- function(x, ...) {
     BIC = stats::BIC(x),
     df.residual = stats::df.residual(x),
     nobs = stats::nobs(x),
-    p.value = 1 - stats::pchisq(2 * diff(x$loglik), sum(x$df) - x$idf),
+    p.value = stats::pchisq(2 * diff(x$loglik), sum(x$df) - x$idf, lower.tail = FALSE),
     na_types = "iirrrriir"
   )
 }


### PR DESCRIPTION
Hi there,

This is relatively minor but I was looking at the source code for an unrelated reason and I noticed that in several places you have used the sub-optimal approach to calculating p-values.

You have coded `1 - ...` instead of using the `lower.tail = FALSE` argument of the distribution functions. The `1 - ...` calculation loses numerical precision.

Below are some examples which show this - admittedly you only see this with very large values of a z/t/X^2/F statistic, but it is probably worth using the more precise calculation. For example, for a z-test the `1 - ...` calculation reports `0` for approx. abs(Z) > 8.3 , whereas the `lower.tail = FALSE` calculation will give you a p-value up to abs(Z) approx 37.5 (which is approx `abs(qnorm(.Machine$double.xmin / 2))`).

``` r
statistic <- -7.5
2 * (1 - stats::pnorm(abs(statistic)))
#> [1] 6.37268e-14
2 * (stats::pnorm(abs(statistic), lower.tail = FALSE))
#> [1] 6.381783e-14

statistic <- -8.3
2 * (1 - stats::pnorm(abs(statistic)))
#> [1] 0
2 * (stats::pnorm(abs(statistic), lower.tail = FALSE))
#> [1] 1.041114e-16

statistic <- -37.5 # approx qnorm(.Machine$double.xmin / 2)
2 * (1 - stats::pnorm(abs(statistic)))
#> [1] 0
2 * (stats::pnorm(abs(statistic), lower.tail = FALSE))
#> [1] 9.210706e-308
```

<sup>Created on 2024-07-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Also,

* In the lfe-tidiers.R commit I added what I think is a missing `abs()` around the `statistic`
* I added a missing `stats::` qualifier in a few places.

Tom
