### PR TITLE
Fix coeftest bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,10 @@
 * `glance.lm()` now returns non-`NA` values for `statistic`, `p.value`, and `df` 
   for models fitted with a single predictor and no intercept (@jrob95, #1209).
 
+* `tidy` now return non-`NA` values for `conf.lower` and `conf.upper` for
+  a model fitted with only a constant term and cluster robust std errors
+  computed using `vcovCL` from `sandwich` (#1227).
+
 # broom 1.0.6
 
 ## New Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # broom (development version)
 
+* `tidy.coeftest` now returns non-`NA` values for `conf.low` and `conf.high` for
+  a model fitted with only a constant term and cluster robust std errors
+  computed using `vcovCL` from `sandwich` (#1227).
+
 # broom 1.0.7
 
 * Corrected `nobs` entries in `glance.coxph()` output: the package used to 
@@ -24,10 +28,6 @@
 
 * `glance.lm()` now returns non-`NA` values for `statistic`, `p.value`, and `df` 
   for models fitted with a single predictor and no intercept (@jrob95, #1209).
-
-* `tidy` now return non-`NA` values for `conf.lower` and `conf.upper` for
-  a model fitted with only a constant term and cluster robust std errors
-  computed using `vcovCL` from `sandwich` (#1227).
 
 # broom 1.0.6
 

--- a/R/lmtest-tidiers.R
+++ b/R/lmtest-tidiers.R
@@ -54,6 +54,12 @@ tidy.coeftest <- function(x, conf.int = FALSE, conf.level = .95, ...) {
 
   if (conf.int) {
     ci <- broom_confint_terms(x, level = conf.level)
+
+    # Handle `coeftest` one-dimensional case
+    if (all(dim(ci) == c(1, 3)) && (class(x) == "coeftest")) {
+      ci[["term"]] <- rownames(x)
+    }
+
     ret <- dplyr::left_join(ret, ci, by = "term")
   }
   ret

--- a/R/lmtest-tidiers.R
+++ b/R/lmtest-tidiers.R
@@ -55,8 +55,8 @@ tidy.coeftest <- function(x, conf.int = FALSE, conf.level = .95, ...) {
   if (conf.int) {
     ci <- broom_confint_terms(x, level = conf.level)
 
-    # Handle `coeftest` one-dimensional case
-    if (all(dim(ci) == c(1, 3)) && (class(x) == "coeftest")) {
+    # handle one-dimensional case (#1227)
+    if (identical(dim(ci), c(1L, 3L))) {
       ci[["term"]] <- rownames(x)
     }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -67,7 +67,7 @@ as_augment_tibble <- function(data) {
 is_cran_check <- function() {
   if (identical(Sys.getenv("NOT_CRAN"), "true")) {
     FALSE
-  }
+  } 
   else {
     Sys.getenv("_R_CHECK_PACKAGE_NAME_", "") != ""
   }

--- a/tests/testthat/test-lmtest.R
+++ b/tests/testthat/test-lmtest.R
@@ -52,15 +52,13 @@ test_that("glance.coeftest", {
   check_glance_outputs(gl2) # separately because save = TRUE adds cols
 })
 
-test_that("vcovCL.coeftest", {
+test_that("vcovCL.coeftest (#1227)", {
   m <- lm(Wind ~ 1, data = airquality)
-  output <- tidy(coeftest(m, vcovCL(m, cluster = ~Month)), conf.int = TRUE)
-  expect_equal(
-    output[["conf.low"]], 8.927703,
-    tolerance = 1e-5
-  )
-  expect_equal(
-    output[["conf.high"]], 10.98733,
-    tolerance = 1e-5
+  ct <- coeftest(m, vcovCL(m, cluster = ~Month))
+  ct_confint <- confint(ct, level = .9)
+  output <- tidy(ct, conf.int = TRUE, conf.level = .9)
+  expect_equivalent(
+    output[c("conf.low", "conf.high")],
+    as.data.frame(ct_confint)
   )
 })

--- a/tests/testthat/test-lmtest.R
+++ b/tests/testthat/test-lmtest.R
@@ -51,3 +51,16 @@ test_that("glance.coeftest", {
   check_glance_outputs(gl, gl3)
   check_glance_outputs(gl2) # separately because save = TRUE adds cols
 })
+
+test_that("vcovCL.coeftest", {
+  m <- lm(Wind ~ 1, data = airquality)
+  output <- tidy(coeftest(m, vcovCL(m, cluster = ~Month)), conf.int = TRUE)
+  expect_equal(
+    output[["conf.low"]], 8.927703,
+    tolerance = 1e-5
+  )
+  expect_equal(
+    output[["conf.high"]], 10.98733,
+    tolerance = 1e-5
+  )
+})


### PR DESCRIPTION
When using tidy with coeftest on a model with a constant terms nan are produced
by the confint function.
The reason is that the intercept rowname does not pass through.
The error is inside the `broom_confint_terms` [function](https://github.com/jsr-p/broom/blob/main/R/utilities.R#L507).
When hitting a breakpoint we can inspect the x input variable to the dataframe.
As shown below `names(coef(x))` returns NULL so no rowname will be set and when
it is larger merged onto the other variables the nans are produced.
This PR checks for a one-dimensional object of class `coeftest` and uses the
`rownames` function on the `x` variable to get the correct intercept name onto
the resulting `ci` object.

```txt

Browse[2]> x


t test of coefficients:

            Estimate Std. Error t value Pr(>|t|)
(Intercept)  -3.1039     4.4520 -0.6972    0.486

Browse[2]> class(x)

[1] "coeftest"
Browse[2]> is.null(dim(ci))

[1] FALSE
Browse[2]> coef(x)

[1] -3.103912
Browse[2]> names(coef(x))

NULL
Browse[2]>
```

## Output when using broom package

```txt
# A tibble: 2 × 8
# Groups:   cat [2]
    cat term        estimate std.error statistic p.value conf.low conf.high
  <int> <chr>          <dbl>     <dbl>     <dbl>   <dbl>    <dbl>     <dbl>
1     1 (Intercept)    -3.10      4.45    -0.697   0.486       NA        NA
2     2 (Intercept)    -6.34      4.62    -1.37    0.170       NA        NA
[1] "Second case"
# A tibble: 2 × 8
# Groups:   cat [2]
    cat term        estimate std.error statistic  p.value conf.low conf.high
  <int> <chr>          <dbl>     <dbl>     <dbl>    <dbl>    <dbl>     <dbl>
1     1 (Intercept)    -3.10     0.584     -5.32 1.58e- 7    -4.25     -1.96
2     2 (Intercept)    -6.34     0.594    -10.7  3.97e-24    -7.51     -5.18
[1] "Third case"
# A tibble: 4 × 8
# Groups:   cat [2]
    cat term        estimate std.error statistic   p.value conf.low conf.high
  <int> <chr>          <dbl>     <dbl>     <dbl>     <dbl>    <dbl>     <dbl>
1     1 (Intercept)    -2.97    4.42      -0.671 5.02e-  1   -11.7       5.72
2     1 x               2.05    0.0822    25.0   6.88e- 90     1.89      2.21
3     2 (Intercept)    -5.93    4.39      -1.35  1.78e-  1   -14.6       2.70
4     2 x               2.14    0.0383    56.0   3.85e-217     2.07      2.22
```

### SessionInfo

```txt
R version 4.4.1 (2024-06-14)
Platform: x86_64-pc-linux-gnu
Running under: Arch Linux

Matrix products: default
BLAS:   /usr/lib/libblas.so.3.12.0
LAPACK: /usr/lib/liblapack.so.3.12.0

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C
 [3] LC_TIME=en_DK.UTF-8        LC_COLLATE=en_US.UTF-8
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C
 [9] LC_ADDRESS=C               LC_TELEPHONE=C
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C

time zone: Europe/Copenhagen
tzcode source: system (glibc)

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base

other attached packages:
[1] sandwich_3.1-0 readr_2.1.5    purrr_1.0.2    tidyr_1.3.1    dplyr_1.1.4
[6] lmtest_0.9-40  zoo_1.8-12     broom_1.0.5

loaded via a namespace (and not attached):
 [1] backports_1.4.1  utf8_1.2.4       R6_2.5.1         tidyselect_1.2.1
 [5] lattice_0.22-6   tzdb_0.4.0       magrittr_2.0.3   glue_1.7.0
 [9] tibble_3.2.1     pkgconfig_2.0.3  generics_0.1.3   lifecycle_1.0.4
[13] cli_3.6.3        fansi_1.0.6      grid_4.4.1       vctrs_0.6.5
[17] compiler_4.4.1   hms_1.1.3        pillar_1.9.0     rlang_1.1.4
```

## Output when using pull request

```txt
# A tibble: 2 × 8
# Groups:   cat [2]
    cat term        estimate std.error statistic p.value conf.low conf.high
  <int> <chr>          <dbl>     <dbl>     <dbl>   <dbl>    <dbl>     <dbl>
1     1 (Intercept)    -3.10      4.45    -0.697   0.486    -11.9      5.64
2     2 (Intercept)    -6.34      4.62    -1.37    0.170    -15.4      2.73
[1] "Second case"
# A tibble: 2 × 8
# Groups:   cat [2]
    cat term        estimate std.error statistic  p.value conf.low conf.high
  <int> <chr>          <dbl>     <dbl>     <dbl>    <dbl>    <dbl>     <dbl>
1     1 (Intercept)    -3.10     0.584     -5.32 1.58e- 7    -4.25     -1.96
2     2 (Intercept)    -6.34     0.594    -10.7  3.97e-24    -7.51     -5.18
[1] "Third case"
# A tibble: 4 × 8
# Groups:   cat [2]
    cat term        estimate std.error statistic   p.value conf.low conf.high
  <int> <chr>          <dbl>     <dbl>     <dbl>     <dbl>    <dbl>     <dbl>
1     1 (Intercept)    -2.97    4.42      -0.671 5.02e-  1   -11.7       5.72
2     1 x               2.05    0.0822    25.0   6.88e- 90     1.89      2.21
3     2 (Intercept)    -5.93    4.39      -1.35  1.78e-  1   -14.6       2.70
4     2 x               2.14    0.0383    56.0   3.85e-217     2.07      2.22
```

## Test script

```R
# devtools::load_all("/home/jsr-p/gh-repos/forks/broom")
library(broom)
library(lmtest)
library(dplyr)
library(tidyr)
library(purrr)
library(readr)
library(sandwich)

sessionInfo()

set.seed(999)
df <- data.frame(
  id = rep(1:10, each = 100),
  cs = rep(1:10, times = 100),
  cat = rep(1:2, times = 500),
  x = 4 * rnorm(1000)
)
df <- df |>
  mutate(
    y = 1 + 2 * x + 2 * as.numeric(as.factor(id)) - 3 * as.numeric(as.factor(cs)) + rnorm(1000)
  )


robust_se <- function(x) {
  tidy(
    coeftest(
      x,
      vcovCL(x, cluster = ~ id + cs)
    ),
    conf.int = TRUE
  )
}

df |>
  group_by(cat) |>
  nest() |>
  mutate(model = map(data, ~ lm(y ~ 1, data = .))) |>
  mutate(
    tidy = map(model, robust_se)
  ) |>
  select(!c("data", "model")) |>
  unnest(tidy)


print("Second case")
df |>
  group_by(cat) |>
  nest() |>
  mutate(model = map(data, ~ lm(y ~ 1, data = .))) |>
  mutate(tidy = map(model, \(x) tidy(x, conf.int = TRUE))) |>
  select(!c("data", "model")) |>
  unnest(tidy)


print("Third case")
df |>
  group_by(cat) |>
  nest() |>
  mutate(model = map(data, ~ lm(y ~ 1 + x, data = .))) |>
  mutate(
    tidy = map(model, robust_se)
  ) |>
  select(!c("data", "model")) |>
  unnest(tidy)
```