### PR TITLE
add '-2*log(L)' to anova tidy renamer list

### DIFF
--- a/R/stats-anova.R
+++ b/R/stats-anova.R
@@ -84,7 +84,9 @@ tidy.anova <- function(x, ...) {
     "edf" = "edf",
     "Ref.df" = "ref.df",
     "loglik" = "logLik",
-    ".rownames" = "term"
+    ".rownames" = "term",
+    "-2*log(L)" = "minus2logL",
+    "X.2.log.L." = "minus2logL"
   )
 
   names(renamers) <- make.names(names(renamers))


### PR DESCRIPTION
We recently changed the name "deviance" to "-2\*log(L)" in `anova` output in `lme4`  ("deviance" is technically incorrect, and confusing, for the value we were actually reporting). This does not affect `broom` directly, but it affects the [cardx package](https://github.com/insightsengineering/cardx), which calls `broom::tidy()` on `anova()` output from lme4. Because "-2*log(L)" isn't in the [list of renamers](https://github.com/tidymodels/broom/blob/main/R/stats-anova.R#L55-L88) that `tidy.anova` uses, this now throws a warning (and makes `cardx` fail its checks).

It's a little hard to implement a test for this change since `lme4` is handled by `broom.mixed` and not `broom` ...  you could do something hacky like this, but I'll leave it up to you to decide if you want to do that.

```r
m <- lm(mpg ~ cyl + hp, mtcars)
aa <- anova(m)
names(aa)[5] <- "-2*log(L)"
expect_no_warning(broom::tidy(aa))
```

I know pushing out a new release is a hassle, but at least it's been 6 months since the last release and there are some other improvements to include in this release ... do you think you might be able to do this soon ... ?
