### PR TITLE
Edit tidy.pyears so that strata are tidied.

### DIFF
--- a/R/survival-pyears.R
+++ b/R/survival-pyears.R
@@ -50,10 +50,20 @@
 #'
 tidy.pyears <- function(x, ...) {
   if (is.null(x$data)) {
-    ret <- purrr::compact(unclass(x)[c("pyears", "n", "event", "expected")])
+    ret <- purrr::map(
+      c("pyears", "n", "event", "expected"), ~{
+        val <- x[[.x]]
+        if(is.null(val)){
+          return(NULL)
+        }
+        as.data.frame.table(val, responseName = .x)
+      }) %>% 
+      purrr::compact() %>% 
+      purrr::reduce(dplyr::left_join)
   } else {
     ret <- x$data
   }
+  
   as_tibble(as.data.frame(ret)) # allow vector recycling!
 }
 


### PR DESCRIPTION
I was working on some survival analyses which required the use of `survival::pyears`.  In particular, I needed to compute person years and number of events within some strata.  The code I used was something like

``` r
library(tidyverse)
library(survival)


x <- lung %>% 
     select(time, status, sex, age) %>% 
     mutate(
       age = factor(ntile(age, 5))
     )


fit <- pyears(Surv(time, status) ~ sex + age, data=x)

broom::tidy(fit)
#> # A tibble: 2 × 15
#>   pyears.1 pyears.2 pyears.3 pyears.4 pyears.5   n.1   n.2   n.3   n.4   n.5
#>      <dbl>    <dbl>    <dbl>    <dbl>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1     18.9     24.8     21.3     22.3     19.7    24    24    28    31    31
#> 2     21.8     17.0     16.1     16.2     12.4    22    22    18    14    14
#> # ℹ 5 more variables: event.1 <dbl>, event.2 <dbl>, event.3 <dbl>,
#> #   event.4 <dbl>, event.5 <dbl>
```

<sup>Created on 2025-06-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


You can see that there is one column for each strata, which to my understanding is _not tidy!_.

I've edited the `tidy.pyears` function so that the output looks like

``` r
library(tidyverse)
library(survival)


x <- lung %>% 
     select(time, status, sex, age, wt.loss) %>% 
     mutate(
       age = factor(ntile(age, 5)),
       wt.loss = factor(ntile(wt.loss, 5))
     )


fit <- pyears(Surv(time, status) ~ sex + age, data=x)

broom::tidy(fit)
#> Joining with `by = join_by(sex, age)`
#> Joining with `by = join_by(sex, age)`
#> # A tibble: 10 × 5
#>    sex   age   pyears     n event
#>    <fct> <fct>  <dbl> <dbl> <dbl>
#>  1 1     1       18.9    24    19
#>  2 2     1       21.8    22    11
#>  3 1     2       24.8    24    19
#>  4 2     2       17.0    22    14
#>  5 1     3       21.3    28    22
#>  6 2     3       16.1    18     8
#>  7 1     4       22.3    31    24
#>  8 2     4       16.2    14    11
#>  9 1     5       19.7    31    28
#> 10 2     5       12.4    14     9
```

<sup>Created on 2025-06-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


Now, there is one row per strata,l which to my understanding is tidy.

