### PR TITLE
Update Plausible analytics snippet

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,7 +10,12 @@ template:
   includes:
     in_header: |
       <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
-      <script defer data-domain="broom.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-9lH7s8RUnCrG8Rx5Mi_8F.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
 
 development:
   mode: auto


### PR DESCRIPTION
## Summary

- Replace the old Plausible `<script defer data-domain=...>` tag with the new async snippet that includes `plausible.init()`

## Context

Plausible has updated their recommended tracking snippet. The new format uses `async` loading with an inline init script, and no longer requires the `data-domain` attribute.
